### PR TITLE
Add Python 3.14.4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3']
-
+        # Test against multiple patch versions as CinderX references internal
+        # CPython functions and structures which can lead to ABI problems.  See
+        # cinderx/UpstreamBorrow for more details.
+        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3', '3.14.4']
 
     steps:
     - name: Checkout CinderX
@@ -37,7 +39,7 @@ jobs:
       run: |
         uv run python -c 'import cinderx ; print(cinderx.get_import_error()) ; assert cinderx.is_initialized()'
 
-    - name: Install Pytest
+    - name: Install pytest
       run: uv pip install pytest
 
     - name: Run Tests
@@ -51,11 +53,13 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout CinderX
+        uses: actions/checkout@v6
 
-      # cibuildwheel uses a docker container so the Python version is irrelevant
-      # here.
-      - uses: actions/setup-python@v6
+      # cibuildwheel uses Python from a docker container.  The Python version is
+      # controlled by selecting the docker image version in pyproject.toml.
+      - name: Set up Python
+        uses: actions/setup-python@v6
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -65,18 +69,16 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3']
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout CinderX
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+      # An sdist is just source code and doesn't contain compiled artifacts, it
+      # doesn't need to be built per patch version.
+      - name: Set up Python
+        uses: actions/setup-python@v6
 
       - name: Install build tools
         run: python -m pip install build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,13 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout CinderX
+        uses: actions/checkout@v6
 
-      # cibuildwheel uses a docker container so the Python version is irrelevant
-      # here.
-      - uses: actions/setup-python@v6
+      # cibuildwheel uses Python from a docker container.  The Python version is
+      # controlled by selecting the docker image version in pyproject.toml.
+      - name: Set up Python
+        uses: actions/setup-python@v6
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -37,7 +39,8 @@ jobs:
         env:
           CINDERX_VERSION_PATCH: ${{ inputs.patch_version || '0' }}
 
-      - uses: actions/upload-artifact@v6
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -45,17 +48,15 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.14.3']
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout CinderX
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+      # An sdist is just source code and doesn't contain compiled artifacts, it
+      # doesn't need to be built per patch version.
+      - name: Set up Python
+        uses: actions/setup-python@v6
 
       - name: Install build tools
         run: python -m pip install build
@@ -65,7 +66,8 @@ jobs:
         env:
           CINDERX_VERSION_PATCH: ${{ inputs.patch_version || '0' }}
 
-      - uses: actions/upload-artifact@v6
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -80,7 +82,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ However these features are not compatible with the stock CPython runtime yet.
 
 ## Requirements
 
-- Python 3.14.3 or later
+- Python 3.14
 - Linux (x86_64)
 - GCC 13+ or Clang 18+
 


### PR DESCRIPTION
At the same time, stop generating source distributions for all 3.14.x patch versions.  It doesn't do anything.  Only the tests need the Python matrix.

Add names to the action steps as well.