### PR TITLE
Don't fail fast on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     name: Run Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let test failures on one platform block other platforms.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest]
         # Test against multiple patch versions as CinderX references internal
@@ -52,6 +54,8 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # Don't let build failures on one platform block other platforms.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
 


### PR DESCRIPTION
Currently Windows is broken and we're not getting any signals as a result. Ideally we'd still have Linux signals available.