### PR TITLE
Define NOMINMAX on Windows builds

### DIFF
--- a/cinderx/Common/util.h
+++ b/cinderx/Common/util.h
@@ -271,12 +271,6 @@ class Worklist {
   std::unordered_set<T> set_;
 };
 
-#ifdef max
-#undef max
-#endif
-#ifdef min
-#undef min
-#endif
 template <int N, std::integral T>
 bool fitsSignedInt(T val) {
   static_assert(N > 0 && N <= 64, "N must be between 1 and 64");

--- a/cinderx/Jit/bytecode_offsets.h
+++ b/cinderx/Jit/bytecode_offsets.h
@@ -11,14 +11,6 @@
 #include "cinderx/Common/log.h"
 #include "fmt/ostream.h"
 
-#ifdef max
-#undef max
-#endif
-
-#ifdef min
-#undef min
-#endif
-
 #include <concepts>
 #include <limits>
 #include <ostream>

--- a/cinderx/Jit/code_runtime.h
+++ b/cinderx/Jit/code_runtime.h
@@ -13,13 +13,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
-
 namespace jit {
 
 constexpr ptrdiff_t kInvalidYieldFromOffset =

--- a/cinderx/Jit/codegen/copy_graph.h
+++ b/cinderx/Jit/codegen/copy_graph.h
@@ -4,10 +4,6 @@
 
 #include "cinderx/Jit/intrusive_list.h"
 
-#ifdef max
-#undef max
-#endif
-
 #include <iterator>
 #include <limits>
 #include <map>

--- a/cinderx/Jit/codegen/gen_asm.cpp
+++ b/cinderx/Jit/codegen/gen_asm.cpp
@@ -38,13 +38,6 @@
 
 #include <fmt/format.h>
 
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
-
 #include <algorithm>
 #include <cstdint>
 #include <iostream>

--- a/cinderx/Jit/lir/generator.cpp
+++ b/cinderx/Jit/lir/generator.cpp
@@ -19,14 +19,6 @@ extern "C" {
 #endif
 }
 
-#ifdef max
-#undef max
-#endif
-
-#ifdef min
-#undef min
-#endif
-
 #include "cinderx/Common/log.h"
 #include "cinderx/Common/py-portability.h"
 #include "cinderx/Common/util.h"

--- a/cinderx/Jit/lir/regalloc.h
+++ b/cinderx/Jit/lir/regalloc.h
@@ -7,10 +7,6 @@
 #include "cinderx/Jit/containers.h"
 #include "cinderx/Jit/lir/block.h"
 
-#ifdef max
-#undef max
-#endif
-
 #include <memory>
 #include <ostream>
 

--- a/cinderx/Jit/pyjit.cpp
+++ b/cinderx/Jit/pyjit.cpp
@@ -40,13 +40,6 @@
 #include "cinderx/Jit/perf_jitdump.h"
 #include "cinderx/module_state.h"
 
-#ifdef min
-#undef min
-#endif
-#ifdef max
-#undef max
-#endif
-
 #ifndef WIN32
 #include <dlfcn.h>
 #endif

--- a/cinderx/python.h
+++ b/cinderx/python.h
@@ -7,6 +7,12 @@
 
 #pragma once
 
+// Avoid conflicts with `min` and `max` on Windows platforms.
+#ifdef WIN32
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include <Python.h>
 
 #if PY_VERSION_HEX >= 0x030E0000


### PR DESCRIPTION
Keeps conflicting with std::max() and std::min().