### PR TITLE
Don't emit SyntaxWarnings for test_jit_exception with pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ classifiers = [
 [project.urls]
 Repository = "https://www.github.com/facebookincubator/cinderx"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+     # test_jit_exception intentionally tests return/break/continue inside
+     # finally blocks, which emit noisy SyntaxWarnings at compile time.
+    "ignore::SyntaxWarning:test_cinderx.test_jit_exception",
+]
+
 [tool.cibuildwheel]
 build = ["cp314-manylinux_x86_64", "cp314-musllinux_x86_64", "cp314-manylinux_aarch64", "cp314-musllinux_aarch64"]
 environment = { CINDERX_ENABLE_PGO = "1", CINDERX_ENABLE_LTO = "1" }


### PR DESCRIPTION
This file intentionally tests bad syntax.  Sending the warnings to stderr is just noisy.

Example of how the warnings look like: https://github.com/facebookincubator/cinderx/actions/runs/24893413448/job/72891538606#step:10:44.