### PR TITLE
Use `if constexpr` for a few PY_VERSION_HEX checks

### DIFF
--- a/cinderx/Jit/generators_core.cpp
+++ b/cinderx/Jit/generators_core.cpp
@@ -92,14 +92,14 @@ PyObject* JitCoro_GetAwaitableIter(PyObject* o) {
     return res;
   }
 
-  PyErr_Format(
-      PyExc_TypeError,
-#if PY_VERSION_HEX >= 0x030E0000
-      "'%.100s' object can't be awaited",
-#else
-      "object %.100s can't be used in 'await' expression",
-#endif
-      ot->tp_name);
+  if constexpr (PY_VERSION_HEX >= 0x030E0000) {
+    PyErr_Format(PyExc_TypeError, "'%.100s' object can't be awaited", ot->tp_name);
+  } else {
+    PyErr_Format(
+        PyExc_TypeError,
+        "object %.100s can't be used in 'await' expression",
+        ot->tp_name);
+  }
   return nullptr;
 }
 }

--- a/cinderx/Jit/jit_rt.cpp
+++ b/cinderx/Jit/jit_rt.cpp
@@ -912,9 +912,9 @@ JITRT_LoadGlobal(PyObject* globals, PyObject* builtins, PyObject* name) {
         name);
   }
   // PyDict_LoadGlobal returns a new reference on 3.14+
-#if PY_VERSION_HEX < 0x030E0000
-  Py_XINCREF(result);
-#endif
+  if constexpr (PY_VERSION_HEX < 0x030E0000) {
+    Py_XINCREF(result);
+  }
   return result;
 }
 


### PR DESCRIPTION
These don't need to be preprocessor directives.