### PR TITLE
skip oss removed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (WINDOWS)
-    set(SHARED_FLAGS "-DPy_BUILD_CORE -DPy_BUILD_CORE_MODULE")
+  set(SHARED_FLAGS "-DPy_BUILD_CORE -DPy_BUILD_CORE_MODULE")
+  set(CXX_FLAGS "")
 else()
-    set(SHARED_FLAGS "-DPy_BUILD_CORE -DPy_BUILD_CORE_MODULE -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wno-attributes -Wno-c99-designator -Wno-c++11-narrowing -Wno-cast-function-type -Wno-cast-function-type-mismatch -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-null-pointer-subtraction -Wno-parentheses -Wno-sign-compare -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-parameter")
+  set(SHARED_FLAGS "-DPy_BUILD_CORE -DPy_BUILD_CORE_MODULE -fPIC -fvisibility=hidden -Wall -Wextra -Wno-attributes -Wno-c99-designator -Wno-c++11-narrowing -Wno-cast-function-type -Wno-cast-function-type-mismatch -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-null-pointer-subtraction -Wno-parentheses -Wno-sign-compare -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-parameter")
+  set(CXX_FLAGS "-fvisibility-inlines-hidden")
 endif()
 
 macro(set_flag VAR)
@@ -67,7 +69,7 @@ set_flag(ENABLE_USDT)
 set_flag(ENABLE_ZLIB)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SHARED_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SHARED_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_FLAGS} ${SHARED_FLAGS}")
 
 ##############################################################################
 # Apply LTO (Link-Time Optimization) if enabled

--- a/build/fbcode_builder/manifests/rebalancer
+++ b/build/fbcode_builder/manifests/rebalancer
@@ -14,6 +14,9 @@ branch = main
 [build]
 builder = cmake
 
+[cmake.defines]
+CMAKE_POSITION_INDEPENDENT_CODE=ON
+
 [dependencies]
 boost
 fbthrift

--- a/cinderx/Common/util.h
+++ b/cinderx/Common/util.h
@@ -58,6 +58,17 @@ constexpr bool kPyRefDebug =
     false;
 #endif
 
+// True when CinderX is built against a free-threaded (Py_GIL_DISABLED) Python.
+//
+// When false, code can assume the GIL is held.  When true, it cannot, the GIL
+// might still be held at any given moment but that's no longer guaranteed.
+constexpr bool kFreeThreadedBuild =
+#ifdef Py_GIL_DISABLED
+    true;
+#else
+    false;
+#endif
+
 struct jit_string_deleter {
   void operator()(jit_string_t* ss) const {
     ss_free(ss);

--- a/cinderx/Interpreter/3.15/Includes/Python/ceval_macros.h
+++ b/cinderx/Interpreter/3.15/Includes/Python/ceval_macros.h
@@ -328,10 +328,23 @@ GETITEM(PyObject *v, Py_ssize_t i) {
 #define CONSTS() _PyFrame_GetCode(frame)->co_consts
 #define NAMES() _PyFrame_GetCode(frame)->co_names
 
+#if defined(WITH_DTRACE) && !defined(Py_BUILD_CORE_MODULE)
+static void dtrace_function_entry(_PyInterpreterFrame *);
+static void dtrace_function_return(_PyInterpreterFrame *);
+
 #define DTRACE_FUNCTION_ENTRY()  \
     if (PyDTrace_FUNCTION_ENTRY_ENABLED()) { \
         dtrace_function_entry(frame); \
     }
+
+#define DTRACE_FUNCTION_RETURN() \
+    if (PyDTrace_FUNCTION_RETURN_ENABLED()) { \
+        dtrace_function_return(frame); \
+    }
+#else
+#define DTRACE_FUNCTION_ENTRY() ((void)0)
+#define DTRACE_FUNCTION_RETURN() ((void)0)
+#endif
 
 /* This takes a uint16_t instead of a _Py_BackoffCounter,
  * because it is used directly on the cache entry in generated code,

--- a/cinderx/Interpreter/3.15/Includes/Python/ceval_macros.h
+++ b/cinderx/Interpreter/3.15/Includes/Python/ceval_macros.h
@@ -168,7 +168,6 @@
 #define STOP_TRACING() ((void)(0));
 #endif
 
-
 /* PRE_DISPATCH_GOTO() does lltrace if enabled. Normally a no-op */
 #ifdef Py_DEBUG
 #define PRE_DISPATCH_GOTO() if (frame->lltrace >= 5) { \

--- a/cinderx/Interpreter/3.15/Includes/generated_cases.c.h
+++ b/cinderx/Interpreter/3.15/Includes/generated_cases.c.h
@@ -646,11 +646,16 @@
             _PyStackRef ds;
             _PyStackRef ss;
             _PyStackRef value;
-            // _GUARD_NOS_ANY_DICT
+            // _GUARD_NOS_DICT_SUBSCRIPT
             {
                 nos = stack_pointer[-2];
                 PyObject *o = PyStackRef_AsPyObjectBorrow(nos);
-                if (!PyAnyDict_CheckExact(o)) {
+                if (!Py_TYPE(o)->tp_as_mapping) {
+                    UPDATE_MISS_STATS(BINARY_OP);
+                    assert(_PyOpcode_Deopt[opcode] == (BINARY_OP));
+                    JUMP_TO_PREDICTED(BINARY_OP);
+                }
+                if (Py_TYPE(o)->tp_as_mapping->mp_subscript != _PyDict_Subscript) {
                     UPDATE_MISS_STATS(BINARY_OP);
                     assert(_PyOpcode_Deopt[opcode] == (BINARY_OP));
                     JUMP_TO_PREDICTED(BINARY_OP);
@@ -663,18 +668,12 @@
                 dict_st = nos;
                 PyObject *sub = PyStackRef_AsPyObjectBorrow(sub_st);
                 PyObject *dict = PyStackRef_AsPyObjectBorrow(dict_st);
-                assert(PyAnyDict_CheckExact(dict));
+                assert(Py_TYPE(dict)->tp_as_mapping->mp_subscript == _PyDict_Subscript);
                 STAT_INC(BINARY_OP, hit);
-                PyObject *res_o;
                 _PyFrame_SetStackPointer(frame, stack_pointer);
-                int rc = PyDict_GetItemRef(dict, sub, &res_o);
+                PyObject *res_o = _PyDict_Subscript(dict, sub);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
-                if (rc == 0) {
-                    _PyFrame_SetStackPointer(frame, stack_pointer);
-                    _PyErr_SetKeyError(sub);
-                    stack_pointer = _PyFrame_GetStackPointer(frame);
-                }
-                if (rc <= 0) {
+                if (res_o == NULL) {
                     JUMP_TO_LABEL(error);
                 }
                 res = PyStackRef_FromPyObjectSteal(res_o);
@@ -1922,6 +1921,14 @@
                 }
                 PyTypeObject *tp = (PyTypeObject *)callable_o;
                 if (FT_ATOMIC_LOAD_UINT32_RELAXED(tp->tp_version_tag) != type_version) {
+                    UPDATE_MISS_STATS(CALL);
+                    assert(_PyOpcode_Deopt[opcode] == (CALL));
+                    JUMP_TO_PREDICTED(CALL);
+                }
+            }
+            // _CHECK_RECURSION_REMAINING
+            {
+                if (tstate->py_recursion_remaining <= 1) {
                     UPDATE_MISS_STATS(CALL);
                     assert(_PyOpcode_Deopt[opcode] == (CALL));
                     JUMP_TO_PREDICTED(CALL);
@@ -9353,6 +9360,7 @@
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(INSTRUMENTED_YIELD_VALUE);
+            opcode = INSTRUMENTED_YIELD_VALUE;
             _PyStackRef val;
             _PyStackRef value;
             _PyStackRef retval;
@@ -9398,13 +9406,12 @@
                 ((_PyThreadStateImpl *)tstate)->generator_return_kind = GENERATOR_YIELD;
                 FT_ATOMIC_STORE_INT8_RELEASE(gen->gi_frame_state, FRAME_SUSPENDED + oparg);
                 assert(INLINE_CACHE_ENTRIES_SEND == INLINE_CACHE_ENTRIES_FOR_ITER);
-                #if TIER_ONE
-                assert(frame->instr_ptr->op.code == INSTRUMENTED_LINE ||
-                  frame->instr_ptr->op.code == INSTRUMENTED_INSTRUCTION ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == FOR_ITER ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == INTERPRETER_EXIT ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == ENTER_EXECUTOR);
+                #if TIER_ONE && defined(Py_DEBUG)
+                if (!PyStackRef_IsNone(frame->f_executable)) {
+                    int i = frame->instr_ptr - _PyFrame_GetBytecode(frame);
+                    int opcode = _Py_GetBaseCodeUnit(_PyFrame_GetCode(frame), i).op.code;
+                    assert(opcode == SEND || opcode == FOR_ITER);
+                }
                 #endif
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 LOAD_IP(1 + INLINE_CACHE_ENTRIES_SEND);
@@ -13482,11 +13489,16 @@
             _PyStackRef dict_st;
             _PyStackRef sub;
             _PyStackRef st;
-            // _GUARD_NOS_DICT
+            // _GUARD_NOS_DICT_STORE_SUBSCRIPT
             {
                 nos = stack_pointer[-2];
                 PyObject *o = PyStackRef_AsPyObjectBorrow(nos);
-                if (!PyDict_CheckExact(o)) {
+                if (!Py_TYPE(o)->tp_as_mapping) {
+                    UPDATE_MISS_STATS(STORE_SUBSCR);
+                    assert(_PyOpcode_Deopt[opcode] == (STORE_SUBSCR));
+                    JUMP_TO_PREDICTED(STORE_SUBSCR);
+                }
+                if (Py_TYPE(o)->tp_as_mapping->mp_ass_subscript != _PyDict_StoreSubscript) {
                     UPDATE_MISS_STATS(STORE_SUBSCR);
                     assert(_PyOpcode_Deopt[opcode] == (STORE_SUBSCR));
                     JUMP_TO_PREDICTED(STORE_SUBSCR);
@@ -13499,7 +13511,7 @@
                 dict_st = nos;
                 value = stack_pointer[-3];
                 PyObject *dict = PyStackRef_AsPyObjectBorrow(dict_st);
-                assert(PyDict_CheckExact(dict));
+                assert(Py_TYPE(dict)->tp_as_mapping->mp_ass_subscript == _PyDict_StoreSubscript);
                 STAT_INC(STORE_SUBSCR, hit);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 int err = _PyDict_SetItem_Take2((PyDictObject *)dict,
@@ -14386,6 +14398,7 @@
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(YIELD_VALUE);
+            opcode = YIELD_VALUE;
             _PyStackRef value;
             _PyStackRef retval;
             // _MAKE_HEAP_SAFE
@@ -14414,13 +14427,12 @@
                 ((_PyThreadStateImpl *)tstate)->generator_return_kind = GENERATOR_YIELD;
                 FT_ATOMIC_STORE_INT8_RELEASE(gen->gi_frame_state, FRAME_SUSPENDED + oparg);
                 assert(INLINE_CACHE_ENTRIES_SEND == INLINE_CACHE_ENTRIES_FOR_ITER);
-                #if TIER_ONE
-                assert(frame->instr_ptr->op.code == INSTRUMENTED_LINE ||
-                  frame->instr_ptr->op.code == INSTRUMENTED_INSTRUCTION ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == SEND ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == FOR_ITER ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == INTERPRETER_EXIT ||
-                  _PyOpcode_Deopt[frame->instr_ptr->op.code] == ENTER_EXECUTOR);
+                #if TIER_ONE && defined(Py_DEBUG)
+                if (!PyStackRef_IsNone(frame->f_executable)) {
+                    int i = frame->instr_ptr - _PyFrame_GetBytecode(frame);
+                    int opcode = _Py_GetBaseCodeUnit(_PyFrame_GetCode(frame), i).op.code;
+                    assert(opcode == SEND || opcode == FOR_ITER);
+                }
                 #endif
                 stack_pointer = _PyFrame_GetStackPointer(frame);
                 LOAD_IP(1 + INLINE_CACHE_ENTRIES_SEND);

--- a/cinderx/Interpreter/3.15/Includes/generated_cases.c.h
+++ b/cinderx/Interpreter/3.15/Includes/generated_cases.c.h
@@ -9335,6 +9335,7 @@
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 assert(STACK_LEVEL() == 0);
+                DTRACE_FUNCTION_RETURN();
                 _Py_LeaveRecursiveCallPy(tstate);
                 _PyInterpreterFrame *dying = frame;
                 frame = tstate->current_frame = dying->previous;
@@ -9397,6 +9398,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
+                DTRACE_FUNCTION_RETURN();
                 tstate->exc_info = gen->gi_exc_state.previous_item;
                 gen->gi_exc_state.previous_item = NULL;
                 _Py_LeaveRecursiveCallPy(tstate);
@@ -12534,6 +12536,7 @@
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
                 assert(STACK_LEVEL() == 0);
+                DTRACE_FUNCTION_RETURN();
                 _Py_LeaveRecursiveCallPy(tstate);
                 _PyInterpreterFrame *dying = frame;
                 frame = tstate->current_frame = dying->previous;
@@ -14418,6 +14421,7 @@
                 stack_pointer += -1;
                 ASSERT_WITHIN_STACK_BOUNDS(__FILE__, __LINE__);
                 _PyFrame_SetStackPointer(frame, stack_pointer);
+                DTRACE_FUNCTION_RETURN();
                 tstate->exc_info = gen->gi_exc_state.previous_item;
                 gen->gi_exc_state.previous_item = NULL;
                 _Py_LeaveRecursiveCallPy(tstate);
@@ -14564,6 +14568,13 @@ JUMP_TO_LABEL(error);
         }
 
         LABEL(exit_unwind)
+        {
+            assert(_PyErr_Occurred(tstate));
+            DTRACE_FUNCTION_RETURN();
+            JUMP_TO_LABEL(exit_unwind_notrace);
+        }
+
+        LABEL(exit_unwind_notrace)
         {
             assert(_PyErr_Occurred(tstate));
             _Py_LeaveRecursiveCallPy(tstate);

--- a/cinderx/Interpreter/3.15/cinderx_opcode_targets.h
+++ b/cinderx/Interpreter/3.15/cinderx_opcode_targets.h
@@ -527,6 +527,7 @@ static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_pop_1_error(TAIL_CALL_PARAMS);
 static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_error(TAIL_CALL_PARAMS);
 static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_exception_unwind(TAIL_CALL_PARAMS);
 static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_exit_unwind(TAIL_CALL_PARAMS);
+static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_exit_unwind_notrace(TAIL_CALL_PARAMS);
 static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_start_frame(TAIL_CALL_PARAMS);
 static PyObject *Py_PRESERVE_NONE_CC _TAIL_CALL_stop_tracing(TAIL_CALL_PARAMS);
 

--- a/cinderx/Jit/codegen/autogen.cpp
+++ b/cinderx/Jit/codegen/autogen.cpp
@@ -64,7 +64,7 @@ arch::Mem AsmIndirectOperandBuilder(const OperandBase* operand) {
     return asmjit::x86::ptr(
         x86::gpq(base->getPhyRegister().loc),
         x86::gpq(index->getPhyRegister().loc),
-        indirect->getMultipiler(),
+        indirect->getMultiplier(),
         indirect->getOffset());
   }
 #elif defined(CINDER_AARCH64)
@@ -1301,7 +1301,7 @@ void leaIndirect(
         output,
         base,
         AT::getGp(indexRegOperand),
-        indirect->getMultipiler());
+        indirect->getMultiplier());
 
     base = output;
   }
@@ -1325,7 +1325,7 @@ arch::Mem ptrIndirect(
         scratch1,
         base,
         AT::getGp(indexRegOperand),
-        indirect->getMultipiler());
+        indirect->getMultiplier());
 
     base = scratch1;
   }

--- a/cinderx/Jit/codegen/autogen.cpp
+++ b/cinderx/Jit/codegen/autogen.cpp
@@ -735,82 +735,6 @@ void translateLoadThreadState(Environ* env, const Instruction* instr) {
 #endif
 }
 
-void translateYieldInitial(Environ* env, const Instruction* instr) {
-#if defined(CINDER_X86_64)
-  arch::Builder* as = env->as;
-
-  // Load tstate into RDI for call to
-  // JITRT_UnlinkGenFrameAndReturnGenDataFooter.
-
-  // Consider avoiding reloading the tstate in from memory if it was already in
-  // a register before spilling. Still needs to be in memory though so it can be
-  // recovered after calling JITRT_MakeGenObject* which will trash it.
-  PhyLocation tstate = instr->getInput(0)->getStackSlot();
-  as->mov(x86::rdi, x86::ptr(x86::rbp, tstate.loc));
-
-  emitCall(
-      *env,
-      reinterpret_cast<uint64_t>(JITRT_UnlinkGenFrameAndReturnGenDataFooter),
-      instr);
-  // This will return pointers to a generator in RAX and JIT data in RDX.
-
-  // Arbitrary scratch register for use in emitStoreGenYieldPoint(). Any
-  // caller-saved register not used in this scope will do because we're on the
-  // exit path now.
-  auto scratch_r = x86::r9;
-  env->pending_yield_resume_label = as->newLabel();
-  emitStoreGenYieldPoint(
-      as,
-      env,
-      instr,
-      env->pending_yield_resume_label,
-      x86::rdx,
-      scratch_r,
-      false /* is_yield_from */);
-
-  // The jmp to exit and resume label binding are handled by separate
-  // kBranchToYieldExit and kResumeGenYield instructions.
-#elif defined(CINDER_AARCH64)
-  arch::Builder* as = env->as;
-
-  // Load tstate into X0 for call to
-  // JITRT_UnlinkGenFrameAndReturnGenDataFooter.
-
-  // Consider avoiding reloading the tstate in from memory if it was already in
-  // a register before spilling. Still needs to be in memory though so it can be
-  // recovered after calling JITRT_MakeGenObject* which will trash it.
-  PhyLocation tstate = instr->getInput(0)->getStackSlot();
-  as->ldr(
-      a64::x0,
-      arch::ptr_resolve(as, arch::fp, tstate.loc, arch::reg_scratch_0));
-
-  emitCall(
-      *env,
-      reinterpret_cast<uint64_t>(JITRT_UnlinkGenFrameAndReturnGenDataFooter),
-      instr);
-  // This will return pointers to a generator in X0 and JIT data in X1.
-
-  // Arbitrary scratch register for use in emitStoreGenYieldPoint(). Any
-  // caller-saved register not used in this scope will do because we're on the
-  // exit path now.
-  auto scratch_r = arch::reg_scratch_0;
-  env->pending_yield_resume_label = as->newLabel();
-  emitStoreGenYieldPoint(
-      as,
-      env,
-      instr,
-      env->pending_yield_resume_label,
-      a64::x1,
-      scratch_r,
-      false /* is_yield_from */);
-
-  // The jmp to exit and resume label binding are handled by separate
-  // kBranchToYieldExit and kResumeGenYield instructions.
-#else
-  CINDER_UNSUPPORTED
-#endif
-}
-
 void translateStoreGenYieldPoint(Environ* env, const Instruction* instr) {
 #if defined(CINDER_X86_64)
   arch::Builder* as = env->as;
@@ -2502,9 +2426,6 @@ void AutoTranslator::translateInstr(Environ* env, const Instruction* instr)
     case Instruction::kLoadThreadState:
       translateLoadThreadState(env, instr);
       return;
-    case Instruction::kYieldInitial:
-      translateYieldInitial(env, instr);
-      return;
     case Instruction::kStoreGenYieldPoint:
       translateStoreGenYieldPoint(env, instr);
       return;
@@ -2951,9 +2872,6 @@ void AutoTranslator::translateInstr(Environ* env, const Instruction* instr)
       return;
     case Instruction::kLoadThreadState:
       translateLoadThreadState(env, instr);
-      return;
-    case Instruction::kYieldInitial:
-      translateYieldInitial(env, instr);
       return;
     case Instruction::kStoreGenYieldPoint:
       translateStoreGenYieldPoint(env, instr);

--- a/cinderx/Jit/codegen/environ.h
+++ b/cinderx/Jit/codegen/environ.h
@@ -42,6 +42,15 @@ struct Environ {
   asmjit::Label hard_exit_label;
   asmjit::Label exit_label;
   asmjit::Label gen_resume_entry_label;
+  asmjit::Label finish_frame_setup;
+  asmjit::Label correct_arg_count;
+  asmjit::Label prologue_exit;
+  asmjit::Label wrapper_exit;
+
+  // Static type check jump table, resolved after code generation.
+  void** static_typecheck_table{nullptr};
+  std::vector<std::pair<int, jit::lir::BasicBlock*>>
+      static_typecheck_jt_entries;
 
   // Resume label shared between StoreGenYieldPoint/YieldInitial and
   // ResumeGenYield. Created by translateStoreGenYieldPoint or

--- a/cinderx/Jit/codegen/environ.h
+++ b/cinderx/Jit/codegen/environ.h
@@ -52,9 +52,9 @@ struct Environ {
   std::vector<std::pair<int, jit::lir::BasicBlock*>>
       static_typecheck_jt_entries;
 
-  // Resume label shared between StoreGenYieldPoint/YieldInitial and
-  // ResumeGenYield. Created by translateStoreGenYieldPoint or
-  // translateYieldInitial (3.12+), bound by translateResumeGenYield.
+  // Resume label shared between StoreGenYieldPoint and ResumeGenYield.
+  // Created by translateStoreGenYieldPoint, bound by
+  // translateResumeGenYield.
   asmjit::Label pending_yield_resume_label;
 
   // Map from deopt metadata index to the stage 1 deopt exit LIR block.
@@ -148,7 +148,6 @@ struct Environ {
       inline_frame_map;
 
   FrameMode frame_mode;
-  int initial_yield_spill_size_{-1};
 
   int max_arg_buffer_size{0};
 

--- a/cinderx/Jit/codegen/gen_asm.cpp
+++ b/cinderx/Jit/codegen/gen_asm.cpp
@@ -889,23 +889,6 @@ arch::Gp get_arg_location(int arg) {
   JIT_ABORT("should only be used with first six args");
 }
 
-void NativeGenerator::generateEpilogue(BaseNode* epilogue_cursor) {
-  as_->setCursor(epilogue_cursor);
-
-  // The main epilogue code (generator state, frame unlink, primitive return
-  // flag, callee-saved restore, leave/ret) is now emitted by LIR instructions
-  // in the exit block.
-
-  // Bind exit_label for annotation tracking.
-  as_->bind(env_.exit_label);
-
-#if defined(CINDER_X86_64)
-#elif defined(CINDER_AARCH64)
-#else
-  CINDER_UNSUPPORTED
-#endif
-}
-
 void NativeGenerator::linkDeoptPatchers(const asmjit::CodeHolder& code) {
   JIT_CHECK(code.hasBaseAddress(), "code not generated!");
   uint64_t base = code.baseAddress();
@@ -988,6 +971,96 @@ bool NativeGenerator::hasStaticEntry() const {
   return (code->co_flags & CI_CO_STATICALLY_COMPILED);
 }
 
+void NativeGenerator::generatePrologueBlocks(lir::BasicBlock* frameSetupBlock) {
+  // Pre-assign finish_frame_setup to the frame setup block so
+  // generateAssemblyBody binds it at the block's start.
+  env_.block_label_map[frameSetupBlock] = env_.finish_frame_setup;
+
+  // Build pre-body LIR blocks in assembly order. Each Generate* call appends
+  // blocks to the end. The body blocks (from TranslateFunction) are already
+  // at the front.
+  //
+  // We pre-allocate the entry block (for arg loading), remove it from the
+  // list, generate all other prologue blocks (which append in the correct
+  // order), then push the entry block back at the end — right before the
+  // body blocks. A single rotate then moves the entire prologue prefix to
+  // the front.
+  //
+  // Final block order:
+  //   [wrapper?] [func_entry] [argcount/primitive] [typechecks?]
+  //   [entry(args)] [body...] [exit] [resume?] [deopt_exits]
+  auto& blocks = lir_func_->basicblocks();
+  size_t body_end = blocks.size();
+
+  auto* entry_block = lir_func_->allocateBasicBlock();
+  blocks.pop_back();
+  env_.block_label_map[entry_block] = env_.correct_arg_count;
+
+  // Boxed-return wrapper (if needed) — comes first so the vectorcall entry
+  // falls through to it.
+  Label generic_entry;
+  if (func_->returnsPrimitive()) {
+    generic_entry = as_->newLabel();
+    env_.wrapper_exit = as_->newLabel();
+    lir::GenerateBoxedReturnWrapperBlocks(
+        lir_func_.get(), func_->return_type, generic_entry, env_.wrapper_exit);
+  }
+
+  // Function entry prologue (push rbp / mov rbp, rsp).
+  lir::GenerateFunctionEntryBlock(lir_func_.get());
+  if (generic_entry.isValid()) {
+    env_.block_label_map[lir_func_->basicblocks().back()] = generic_entry;
+  }
+
+  // Argcount check or primitive-args prologue. The correct-args path
+  // branches to correct_arg_count, which is assigned below to either the
+  // typecheck dispatch block (if type checks exist) or the entry block.
+  env_.prologue_exit = as_->newLabel();
+  if (func_->has_primitive_args) {
+    BorrowedRef<_PyTypedArgsInfo> info = func_->prim_args_info;
+    env_.code_rt->addReference(info);
+
+    lir::GeneratePrimitiveArgsPrologueBlock(
+        lir_func_.get(),
+        reinterpret_cast<PyObject*>(info.get()),
+        func_->returnsPrimitiveDouble(),
+        env_.prologue_exit);
+  } else {
+    lir::GenerateArgcountCheckBlocks(
+        lir_func_.get(),
+        GetFunction(),
+        env_.correct_arg_count,
+        env_.prologue_exit);
+  }
+
+  // Static argument type checking (if applicable).
+  if (hasStaticEntry() && !func_->has_primitive_args &&
+      !GetFunction()->typed_args.empty()) {
+    env_.static_arg_typecheck_failed_label = as_->newLabel();
+    auto jt = lir::GenerateStaticTypeCheckBlocks(
+        lir_func_.get(),
+        entry_block,
+        GetFunction()->typed_args,
+        GetFunction()->numArgs(),
+        env_.code_rt,
+        env_.static_arg_typecheck_failed_label);
+    env_.static_typecheck_table = jt.table;
+    env_.static_typecheck_jt_entries = std::move(jt.entries);
+    // Reassign correct_arg_count from entry_block to the dispatch block so
+    // the argcount correct path and reentry go through type checks before
+    // entry(args). entry_block gets a fresh label from emitLIRBlocks.
+    env_.block_label_map.erase(entry_block);
+    env_.block_label_map[jt.dispatch_block] = env_.correct_arg_count;
+  }
+
+  // Push entry_block back and populate it with arg loading.
+  blocks.push_back(entry_block);
+  lir::PopulateEntryBlock(entry_block, env_.arg_locations);
+
+  // Move the prologue blocks from [body_end, end) to the front.
+  std::rotate(blocks.begin(), blocks.begin() + body_end, blocks.end());
+}
+
 void NativeGenerator::generateCode(
     CodeHolder& codeholder,
     lir::BasicBlock* frameSetupBlock) {
@@ -1005,9 +1078,61 @@ void NativeGenerator::generateCode(
   env_.resume_header_and_spill_size = frame_info.header_and_spill_size;
   env_.resume_saved_regs = frame_info.saved_regs;
 
-  // For generators, populate the resume entry block (allocated during LIR
-  // generation) with post-regalloc instructions. This block uses only physical
-  // registers and is translated by autogen alongside the rest of the LIR body.
+  // --- Emit code in final assembly order ---
+  //
+  // The layout is:
+  //   [static entry point]        (optional, at fixed negative offset)
+  //   [reentry with processed args] (at fixed negative offset)
+  //   [vectorcall entry label]
+  //   [LIR blocks: wrapper → func_entry → argcount → typechecks → entry(args)
+  //                → body → exit → resume → deopt_exits]
+  //   [exit label]
+  //   [typecheck failure stub]    (optional)
+  //   [prologue exit stub]        (optional)
+  //   [wrapper exit stub]         (optional)
+  //   [aarch64 constant pool]     (optional)
+
+  // Create labels used by both the raw-asm entry points and the LIR
+  // prologue blocks. finish_frame_setup is bound by generatePrologueBlocks
+  // to the frame setup block; correct_arg_count is bound to the entry block.
+  env_.finish_frame_setup = as_->newLabel();
+  env_.correct_arg_count = as_->newLabel();
+
+  Label static_jmp_location = as_->newLabel();
+  bool has_static_entry = hasStaticEntry();
+  if (has_static_entry) {
+    generateStaticEntryPoint(env_.finish_frame_setup, static_jmp_location);
+  }
+
+  // Reentry point: dispatched to from JITRT_CallWithIncorrectArgcount and
+  // JITRT_CallWithKeywordArgs after argument binding. Must be exactly
+  // JITRT_CALL_REENTRY_OFFSET bytes before the vectorcall entry.
+  auto arg_reentry_cursor = as_->cursor();
+  Label correct_args_entry = as_->newLabel();
+  as_->bind(correct_args_entry);
+  generateFunctionEntry();
+
+#if defined(CINDER_X86_64)
+  as_->short_().jmp(env_.correct_arg_count);
+#elif defined(CINDER_AARCH64)
+  as_->b(env_.correct_arg_count);
+#else
+  CINDER_UNSUPPORTED
+#endif
+
+  env_.addAnnotation("Reentry with processed args", arg_reentry_cursor);
+
+  // Generate prologue LIR blocks (wrapper, func_entry, argcount, typechecks,
+  // entry with arg loading) and prepend them to the body block list.
+  generatePrologueBlocks(frameSetupBlock);
+
+  // Vectorcall entry point. The prologue LIR blocks are first in the block
+  // list, so the vectorcall entry falls through to them.
+  Label vectorcall_entry_label = as_->newLabel();
+  as_->bind(vectorcall_entry_label);
+
+  // Append suffix blocks to the block list. These come after the body's exit
+  // block but before code emission.
   if (GetFunction()->code->co_flags & kCoFlagsAnyGenerator) {
     env_.gi_jit_data_offset = giJITDataOffset();
 
@@ -1017,158 +1142,21 @@ void NativeGenerator::generateCode(
         "Generator must have a resume entry block {}",
         lir_func_->hirFunc()->fullname);
     lir::PopulateResumeEntryBlock(bb, env_.gi_jit_data_offset);
-    // Pre-assign gen_resume_entry_label to this block so generateAssemblyBody
-    // binds it at the block's start.
     env_.block_label_map[bb] = env_.gen_resume_entry_label;
-
-    // The resume entry block was kept out of the block list during regalloc
-    // (it's a placeholder populated post-regalloc). Now that it has
-    // instructions, insert it into the block list for code generation.
-    // Append it at the end — the last block (exit_epilogue) ends with
-    // EpilogueEnd and has no fall-through, so appending is safe and avoids
-    // breaking fall-through relationships established during postalloc.
-    auto& blocks = lir_func_->basicblocks();
-    blocks.push_back(bb);
+    lir_func_->basicblocks().push_back(bb);
   }
 
-  // Pre-assign finish_frame_setup to the LIR entry block so
-  // generateAssemblyBody binds it at the block's start.
-  Label finish_frame_setup = as_->newLabel();
-  env_.block_label_map[frameSetupBlock] = finish_frame_setup;
-
-  // Populate the entry block with arg loading instructions (post-regalloc,
-  // using physical registers from arg_locations).
-  auto* entry_block = lir_func_->basicblocks().front();
-  lir::PopulateEntryBlock(entry_block, env_.arg_locations);
-
-  // Build post-regalloc LIR blocks for static argument type checking.
-  // These blocks are inserted at the front of the LIR function so the
-  // prologue falls through to the dispatch chain → checks → entry block.
-  // We skip primitive args because functions w/ primitive args are handled
-  // by a JIT helper in GeneratePrimitiveArgsPrologueBlock.
-  lir::UnresolvedJumpTable unresolved_jt;
-  if (hasStaticEntry() && !func_->has_primitive_args &&
-      !GetFunction()->typed_args.empty()) {
-    env_.static_arg_typecheck_failed_label = as_->newLabel();
-    unresolved_jt = lir::GenerateStaticTypeCheckBlocks(
-        lir_func_.get(),
-        entry_block,
-        GetFunction()->typed_args,
-        GetFunction()->numArgs(),
-        env_.code_rt,
-        env_.static_arg_typecheck_failed_label);
-  }
-
-  // Build post-regalloc LIR blocks for the vectorcall argcount check
-  // and/or primitive-args prologue. These are inserted at the very front
-  // (before any type check blocks) so the vectorcall entry falls through
-  // to them.
-  Label correct_arg_count = as_->newLabel();
-  asmjit::Label prologue_exit;
-  if (func_->has_primitive_args) {
-    // The block after the primitive prologue is whatever is currently
-    // at the front. The reentry point needs to jump here, past both
-    // the function entry (push rbp) and the primitive prologue (call helper).
-    auto* post_primitive_block = lir_func_->basicblocks().front();
-
-    BorrowedRef<_PyTypedArgsInfo> info = func_->prim_args_info;
-    env_.code_rt->addReference(info);
-
-    prologue_exit = as_->newLabel();
-    lir::GeneratePrimitiveArgsPrologueBlock(
-        lir_func_.get(),
-        reinterpret_cast<PyObject*>(info.get()),
-        func_->returnsPrimitiveDouble(),
-        prologue_exit);
-
-    // Pre-assign correct_arg_count so the reentry point jumps past
-    // the primitive prologue and function entry blocks.
-    env_.block_label_map[post_primitive_block] = correct_arg_count;
-  } else {
-    // The block after the argcount check blocks is whatever is currently
-    // at the front (type check dispatch, or entry block if no type checks).
-    auto* post_argcheck_block = lir_func_->basicblocks().front();
-
-    prologue_exit = as_->newLabel();
-    lir::GenerateArgcountCheckBlocks(
-        lir_func_.get(), GetFunction(), post_argcheck_block, prologue_exit);
-
-    // Pre-assign correct_arg_count to the post-argcheck block so the
-    // correct_args reentry point jumps past the argcount check.
-    env_.block_label_map[post_argcheck_block] = correct_arg_count;
-  }
-
-  // Build a post-regalloc LIR block for the function entry prologue
-  // (push rbp / mov rbp, rsp). Inserted at the very front (after the
-  // argcount/primitive blocks, so it ends up first) because the vectorcall
-  // entry falls through to it. The function entry must happen before the
-  // argcount check since the helpers expect a frame.
-  lir::GenerateFunctionEntryBlock(lir_func_.get());
-  auto* func_entry_block = lir_func_->basicblocks().front();
-
-  // For functions returning primitive types, generate a boxed-return wrapper
-  // as LIR blocks. The wrapper sets up its own frame, calls the inner
-  // function, boxes the primitive result, and returns. These blocks are
-  // inserted at the very front, before the function entry block.
-  Label wrapper_exit;
-  if (func_->returnsPrimitive()) {
-    Label generic_entry = as_->newLabel();
-    wrapper_exit = as_->newLabel();
-    lir::GenerateBoxedReturnWrapperBlocks(
-        lir_func_.get(), func_->return_type, generic_entry, wrapper_exit);
-    env_.block_label_map[func_entry_block] = generic_entry;
-  }
-
-  // Set deopt trampoline address for the stage 2 translator, and generate
-  // the per-guard (stage 1) and per-function (stage 2) deopt exit LIR blocks.
-  // These are appended to the block list after all other post-regalloc blocks.
+  // Generate deopt exit LIR blocks (stage 1 + stage 2). These must be
+  // appended before generateAssemblyBody because the body block translators
+  // (Guard, DeoptPatchpoint) reference the deopt_exit_blocks map.
   env_.deopt_trampoline = GetFunction()->code->co_flags & kCoFlagsAnyGenerator
       ? factory_.deoptTrampolineGenerators()
       : factory_.deoptTrampoline();
   lir::GenerateDeoptExitBlocks(lir_func_.get(), &env_);
 
-  auto prologue_cursor = as_->cursor();
   generateAssemblyBody(codeholder);
 
-  auto epilogue_cursor = as_->cursor();
-
-  as_->setCursor(prologue_cursor);
-  Label static_jmp_location = as_->newLabel();
-
-  bool has_static_entry = hasStaticEntry();
-  if (has_static_entry) {
-    // Setup an entry point for direct static to static
-    // calls using the native calling convention
-    generateStaticEntryPoint(finish_frame_setup, static_jmp_location);
-  }
-
-  // Setup an entry for when we have the correct number of arguments
-  // This will be dispatched back to from JITRT_CallWithIncorrectArgcount and
-  // JITRT_CallWithKeywordArgs when we need to perform complicated
-  // argument binding.
-  auto arg_reentry_cursor = as_->cursor();
-  Label correct_args_entry = as_->newLabel();
-  as_->bind(correct_args_entry);
-  generateFunctionEntry();
-
-#if defined(CINDER_X86_64)
-  as_->short_().jmp(correct_arg_count);
-#elif defined(CINDER_AARCH64)
-  as_->b(correct_arg_count);
-#else
-  CINDER_UNSUPPORTED
-#endif
-
-  env_.addAnnotation("Reentry with processed args", arg_reentry_cursor);
-
-  // Setup the normal entry point that expects that implements the
-  // vectorcall convention
-  Label vectorcall_entry_label = as_->newLabel();
-  as_->bind(vectorcall_entry_label);
-  // The boxed-return wrapper (if any) and prologue are now LIR blocks
-  // emitted during generateAssemblyBody, so nothing more is needed here.
-
-  generateEpilogue(epilogue_cursor);
+  as_->bind(env_.exit_label);
 
   if (env_.static_arg_typecheck_failed_label.isValid()) {
     auto static_typecheck_cursor = as_->cursor();
@@ -1219,15 +1207,15 @@ void NativeGenerator::generateCode(
   // calling the keyword-args or incorrect-argcount helper. The helpers
   // return the result in the ABI return register; we just tear down the
   // minimal frame (push rbp / mov rbp, rsp) and return.
-  if (prologue_exit.isValid()) {
-    as_->bind(prologue_exit);
+  if (env_.prologue_exit.isValid()) {
+    as_->bind(env_.prologue_exit);
     generateFunctionExit();
   }
 
   // Boxed-return wrapper exit stub: the wrapper LIR blocks branch here
   // after boxing (or on error). Tears down the wrapper's own minimal frame.
-  if (wrapper_exit.isValid()) {
-    as_->bind(wrapper_exit);
+  if (env_.wrapper_exit.isValid()) {
+    as_->bind(env_.wrapper_exit);
     generateFunctionExit();
   }
 
@@ -1293,9 +1281,9 @@ void NativeGenerator::generateCode(
 
   // Resolve the static type check jump table entries now that block labels
   // have been bound to code addresses.
-  for (auto& [index, block] : unresolved_jt.entries) {
+  for (auto& [index, block] : env_.static_typecheck_jt_entries) {
     auto label = map_get(env_.block_label_map, block);
-    unresolved_jt.table[index] = reinterpret_cast<void*>(
+    env_.static_typecheck_table[index] = reinterpret_cast<void*>(
         codeholder.baseAddress() + codeholder.labelOffsetFromBase(label));
   }
 

--- a/cinderx/Jit/codegen/gen_asm.cpp
+++ b/cinderx/Jit/codegen/gen_asm.cpp
@@ -712,10 +712,6 @@ void* NativeGenerator::getVectorcallEntry() {
   env_.changed_regs = lsalloc.getChangedRegs();
   env_.exit_label = as_->newLabel();
   env_.frame_mode = GetFunction()->frameMode;
-  if (GetFunction()->code->co_flags & kCoFlagsAnyGenerator) {
-    env_.initial_yield_spill_size_ = lsalloc.initialYieldSpillSize();
-  }
-
   JIT_LOGIF(
       getConfig().log.dump_lir,
       "LIR for {} after register allocation:\n{}",

--- a/cinderx/Jit/codegen/gen_asm.h
+++ b/cinderx/Jit/codegen/gen_asm.h
@@ -85,6 +85,7 @@ class NativeGenerator {
 
   bool hasStaticEntry() const;
   int calcInlineStackSize(const hir::Function* func);
+  void generatePrologueBlocks(lir::BasicBlock* frameSetupBlock);
   void generateCode(asmjit::CodeHolder& code, lir::BasicBlock* frameSetupBlock);
   void generateFunctionEntry();
   void generateFunctionExit();
@@ -117,7 +118,6 @@ class NativeGenerator {
   void saveCallerRegisters(const FrameInfo& frame_info);
 
   int maxInlineStackSize();
-  void generateEpilogue(asmjit::BaseNode* epilogue_cursor);
   void linkDeoptPatchers(const asmjit::CodeHolder& code);
   Py_ssize_t giJITDataOffset();
   void generateStaticEntryPoint(

--- a/cinderx/Jit/generators_core.cpp
+++ b/cinderx/Jit/generators_core.cpp
@@ -92,14 +92,15 @@ PyObject* JitCoro_GetAwaitableIter(PyObject* o) {
     return res;
   }
 
-  PyErr_Format(
-      PyExc_TypeError,
-#if PY_VERSION_HEX >= 0x030E0000
-      "'%.100s' object can't be awaited",
-#else
-      "object %.100s can't be used in 'await' expression",
-#endif
-      ot->tp_name);
+  if constexpr (PY_VERSION_HEX >= 0x030E0000) {
+    PyErr_Format(
+        PyExc_TypeError, "'%.100s' object can't be awaited", ot->tp_name);
+  } else {
+    PyErr_Format(
+        PyExc_TypeError,
+        "object %.100s can't be used in 'await' expression",
+        ot->tp_name);
+  }
   return nullptr;
 }
 }

--- a/cinderx/Jit/hir/simplify.cpp
+++ b/cinderx/Jit/hir/simplify.cpp
@@ -720,116 +720,128 @@ Register* simplifyLoadMethod(Env& env, const LoadMethod* load_meth) {
       *load_meth->frameState());
 }
 
+Register* simplifySubscript(Env& env, const BinaryOp* instr) {
+  BinaryOpKind op = instr->op();
+  Register* lhs = instr->left();
+  Register* rhs = instr->right();
+  JIT_CHECK(
+      op == BinaryOpKind::kSubscript,
+      "simplifySubscript trying to optimize {}",
+      op);
+
+  if (lhs->isA(TDictExact)) {
+    return env.emit<DictSubscr>(lhs, rhs, *instr->frameState());
+  }
+  if (!rhs->isA(TLongExact)) {
+    return nullptr;
+  }
+
+  Type lhs_type = lhs->type();
+  Type rhs_type = rhs->type();
+
+  // Constant tuple subscripted by constant long.
+  if (lhs_type <= TTupleExact && lhs_type.hasObjectSpec() &&
+      rhs_type.hasObjectSpec()) {
+    int overflow;
+    Py_ssize_t index =
+        PyLong_AsLongAndOverflow(rhs_type.objectSpec(), &overflow);
+    if (!overflow) {
+      BorrowedRef<> lhs_obj = lhs_type.objectSpec();
+      if (index >= 0 && index < PyTuple_GET_SIZE(lhs_obj)) {
+        BorrowedRef<> item = PyTuple_GET_ITEM(lhs_obj.get(), index);
+        env.emit<UseType>(lhs, lhs_type);
+        env.emit<UseType>(rhs, rhs_type);
+        return env.emit<LoadConst>(
+            Type::fromObject(env.func.env.addReference(item)));
+      }
+    }
+  }
+
+  // TODO(T255264263). Enable this for FT builds. See P2169673256.
+  if (!kFreeThreadedBuild && (lhs->isA(TListExact) || lhs->isA(TTupleExact))) {
+    // TASK(T93509109): Replace TCInt64 with a less platform-specific
+    // representation of the type, which should be analagous to Py_ssize_t.
+    env.emit<UseType>(lhs, lhs->isA(TListExact) ? TListExact : TTupleExact);
+    env.emit<UseType>(rhs, TLongExact);
+    Register* right_index = env.emit<IndexUnbox>(rhs);
+    env.emit<IsNegativeAndErrOccurred>(right_index, *instr->frameState());
+    Register* adjusted_idx =
+        env.emit<CheckSequenceBounds>(lhs, right_index, *instr->frameState());
+    Py_ssize_t offset = offsetof(PyTupleObject, ob_item);
+    Register* array = lhs;
+    // Lists carry a nested array of ob_item whereas tuples are variable-sized
+    // structs.
+    if (lhs->isA(TListExact)) {
+      array = env.emit<LoadField>(
+          lhs, "ob_item", offsetof(PyListObject, ob_item), TCPtr);
+      offset = 0;
+    }
+    return env.emit<LoadArrayItem>(array, adjusted_idx, lhs, offset, TObject);
+  }
+
+  // Unicode subscript.
+  if (lhs_type <= TUnicodeExact && rhs_type <= TLongExact) {
+    // Constant fold.  This isn't safe in multi-threaded compilation because the
+    // worker doesn't hold the GIL and that's required for creating a new
+    // string.
+    if (!getThreadedCompileContext().compileRunning() &&
+        lhs_type.hasObjectSpec() && rhs_type.hasObjectSpec()) {
+      Py_ssize_t idx = PyLong_AsSsize_t(rhs_type.objectSpec());
+      if (idx == -1 && PyErr_Occurred()) {
+        PyErr_Clear();
+        return nullptr;
+      }
+      Py_ssize_t n = PyUnicode_GetLength(lhs_type.objectSpec());
+      if (idx < -n || idx >= n) {
+        return nullptr;
+      }
+
+      if (idx < 0) {
+        idx += n;
+      }
+
+      ThreadedCompileSerialize guard;
+      Py_UCS4 c = PyUnicode_ReadChar(lhs_type.objectSpec(), idx);
+      PyObject* substr = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, &c, 1);
+      if (substr == nullptr) {
+        return nullptr;
+      }
+      PyUnicode_InternInPlace(&substr);
+      Ref<> result = Ref<>::steal(substr);
+
+      // Use exact types since we're relying on the object specializations.
+      env.emit<UseType>(lhs, lhs_type);
+      env.emit<UseType>(rhs, rhs_type);
+      return env.emit<LoadConst>(
+          Type::fromObject(env.func.env.addReference(std::move(result))));
+    }
+
+    env.emit<UseType>(lhs, TUnicodeExact);
+    env.emit<UseType>(rhs, TLongExact);
+    Register* unboxed_idx = env.emit<IndexUnbox>(rhs);
+    env.emit<IsNegativeAndErrOccurred>(unboxed_idx, *instr->frameState());
+    Register* adjusted_idx =
+        env.emit<CheckSequenceBounds>(lhs, unboxed_idx, *instr->frameState());
+    return env.emit<UnicodeSubscr>(lhs, adjusted_idx, *instr->frameState());
+  }
+
+  return nullptr;
+}
+
 Register* simplifyBinaryOp(Env& env, const BinaryOp* instr) {
   BinaryOpKind op = instr->op();
   Register* lhs = instr->left();
   Register* rhs = instr->right();
 
   if (op == BinaryOpKind::kSubscript) {
-    if (lhs->isA(TDictExact)) {
-      return env.emit<DictSubscr>(lhs, rhs, *instr->frameState());
-    }
-    if (!rhs->isA(TLongExact)) {
-      return nullptr;
-    }
-    Type lhs_type = lhs->type();
-    Type rhs_type = rhs->type();
-    if (lhs_type <= TTupleExact && lhs_type.hasObjectSpec() &&
-        rhs_type.hasObjectSpec()) {
-      int overflow;
-      Py_ssize_t index =
-          PyLong_AsLongAndOverflow(rhs_type.objectSpec(), &overflow);
-      if (!overflow) {
-        PyObject* lhs_obj = lhs_type.objectSpec();
-        if (index >= 0 && index < PyTuple_GET_SIZE(lhs_obj)) {
-          BorrowedRef<> item = PyTuple_GET_ITEM(lhs_obj, index);
-          env.emit<UseType>(lhs, lhs_type);
-          env.emit<UseType>(rhs, rhs_type);
-          return env.emit<LoadConst>(
-              Type::fromObject(env.func.env.addReference(item)));
-        }
-        // Fallthrough
-      }
-      // Fallthrough
-    }
-// TODO(T255264263). Enable this again. See P2169673256.
-#ifndef Py_GIL_DISABLED
-    if (lhs->isA(TListExact) || lhs->isA(TTupleExact)) {
-      // TASK(T93509109): Replace TCInt64 with a less platform-specific
-      // representation of the type, which should be analagous to Py_ssize_t.
-      env.emit<UseType>(lhs, lhs->isA(TListExact) ? TListExact : TTupleExact);
-      env.emit<UseType>(rhs, TLongExact);
-      Register* right_index = env.emit<IndexUnbox>(rhs);
-      env.emit<IsNegativeAndErrOccurred>(right_index, *instr->frameState());
-      Register* adjusted_idx =
-          env.emit<CheckSequenceBounds>(lhs, right_index, *instr->frameState());
-      Py_ssize_t offset = offsetof(PyTupleObject, ob_item);
-      Register* array = lhs;
-      // Lists carry a nested array of ob_item whereas tuples are variable-sized
-      // structs.
-      if (lhs->isA(TListExact)) {
-        array = env.emit<LoadField>(
-            lhs, "ob_item", offsetof(PyListObject, ob_item), TCPtr);
-        offset = 0;
-      }
-      return env.emit<LoadArrayItem>(array, adjusted_idx, lhs, offset, TObject);
-    }
-#endif
-    if (lhs_type <= TUnicodeExact && rhs_type <= TLongExact) { // Unicode subscr
-      if (lhs_type.hasObjectSpec() && rhs_type.hasObjectSpec()) {
-        // This isn't safe in the multi-threaded compilation on 3.12 because
-        // we don't hold the GIL which is required for
-        // PyUnicode_InternInPlace.
-        RETURN_MULTITHREADED_COMPILE(nullptr);
-
-        // Constant propagation
-        Py_ssize_t idx = PyLong_AsSsize_t(rhs_type.objectSpec());
-        if (idx == -1 && PyErr_Occurred()) {
-          PyErr_Clear();
-          return nullptr;
-        }
-        Py_ssize_t n = PyUnicode_GetLength(lhs_type.objectSpec());
-
-        if (idx < -n || idx >= n) {
-          return nullptr;
-        }
-
-        if (idx < 0) {
-          idx += n;
-        }
-
-        ThreadedCompileSerialize guard;
-        Py_UCS4 c = PyUnicode_ReadChar(lhs_type.objectSpec(), idx);
-        PyObject* substr =
-            PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, &c, 1);
-        if (substr == nullptr) {
-          return nullptr;
-        }
-        PyUnicode_InternInPlace(&substr);
-        Ref<> result = Ref<>::steal(substr);
-
-        // Use exact types since we're relying on the object specializations.
-        env.emit<UseType>(lhs, lhs_type);
-        env.emit<UseType>(rhs, rhs_type);
-        return env.emit<LoadConst>(
-            Type::fromObject(env.func.env.addReference(std::move(result))));
-      } else {
-        env.emit<UseType>(lhs, TUnicodeExact);
-        env.emit<UseType>(rhs, TLongExact);
-        Register* unboxed_idx = env.emit<IndexUnbox>(rhs);
-        env.emit<IsNegativeAndErrOccurred>(unboxed_idx, *instr->frameState());
-        Register* adjusted_idx = env.emit<CheckSequenceBounds>(
-            lhs, unboxed_idx, *instr->frameState());
-        return env.emit<UnicodeSubscr>(lhs, adjusted_idx, *instr->frameState());
-      }
-    }
+    return simplifySubscript(env, instr);
   }
 
   if (lhs->isA(TLongExact) && rhs->isA(TLongExact)) {
     // All binary ops on TLong's return mutable so can be freely simplified with
     // no explicit check.
-    if (op == BinaryOpKind::kMatrixMultiply || op == BinaryOpKind::kSubscript) {
-      // These will generate an error at runtime.
+    if (op == BinaryOpKind::kMatrixMultiply) {
+      // This will generate an error at runtime.
       return nullptr;
     }
     env.emit<UseType>(lhs, TLongExact);

--- a/cinderx/Jit/jit_rt.cpp
+++ b/cinderx/Jit/jit_rt.cpp
@@ -912,9 +912,9 @@ JITRT_LoadGlobal(PyObject* globals, PyObject* builtins, PyObject* name) {
         name);
   }
   // PyDict_LoadGlobal returns a new reference on 3.14+
-#if PY_VERSION_HEX < 0x030E0000
-  Py_XINCREF(result);
-#endif
+  if constexpr (PY_VERSION_HEX < 0x030E0000) {
+    Py_XINCREF(result);
+  }
   return result;
 }
 

--- a/cinderx/Jit/lir/function.cpp
+++ b/cinderx/Jit/lir/function.cpp
@@ -38,7 +38,7 @@ void copyIndirect(
   dest_op->setMemoryIndirect(
       dest_base,
       dest_index,
-      source_op->getMultipiler(),
+      source_op->getMultiplier(),
       source_op->getOffset());
 
   // add linked operands to instr_refs

--- a/cinderx/Jit/lir/generator.cpp
+++ b/cinderx/Jit/lir/generator.cpp
@@ -406,18 +406,21 @@ UnresolvedJumpTable GenerateStaticTypeCheckBlocks(
     code_rt->addReference(BorrowedRef(arg.pytype));
   }
 
-  // --- Build the mapping: defaulted_arg_count → check_block ---
-  // Allocate one check block per typed arg (last-to-first order).
+  // Allocate the dispatch block first so it is laid out before all type check
+  // blocks. The reentry short jump targets this block and must reach it within
+  // ±127 bytes.
+  auto* dispatch_block = lir_func->allocateBasicBlock();
+
+  // Allocate check blocks and their MRO blocks interleaved so each MRO loop
+  // block immediately follows its corresponding check block in the layout.
   // check_blocks[0] corresponds to typed_args[checks.size()-1] (the last arg).
   std::vector<BasicBlock*> check_blocks;
-  check_blocks.reserve(typed_args.size());
-  for (size_t i = 0; i < typed_args.size(); i++) {
-    check_blocks.push_back(lir_func->allocateBasicBlock());
-  }
-
-  // Allocate MRO loop blocks for checks that need them.
   std::vector<BasicBlock*> mro_blocks;
-  for (Py_ssize_t i = typed_args.size() - 1; i >= 0; i--) {
+  check_blocks.reserve(typed_args.size());
+  mro_blocks.reserve(typed_args.size());
+  for (size_t k = 0; k < typed_args.size(); k++) {
+    check_blocks.push_back(lir_func->allocateBasicBlock());
+    Py_ssize_t i = typed_args.size() - 1 - k;
     const auto& arg = typed_args[i];
     if (!arg.exact && (arg.threadSafeTpFlags() & Py_TPFLAGS_BASETYPE)) {
       mro_blocks.push_back(lir_func->allocateBasicBlock());
@@ -425,10 +428,6 @@ UnresolvedJumpTable GenerateStaticTypeCheckBlocks(
       mro_blocks.push_back(nullptr);
     }
   }
-
-  // Build the dispatch block.
-  size_t original_count = lir_func->basicblocks().size();
-  auto* dispatch_block = lir_func->allocateBasicBlock();
 
   // Build the dispatch mapping: for each defaulted_arg_count value, determine
   // which check block to jump to (same logic as the original jump table).
@@ -470,6 +469,7 @@ UnresolvedJumpTable GenerateStaticTypeCheckBlocks(
   // Build the unresolved jump table for post-codegen resolution.
   UnresolvedJumpTable result;
   result.table = jump_table;
+  result.dispatch_block = dispatch_block;
   for (const auto& [count, target] : dispatch_entries) {
     result.entries.emplace_back(count, target);
   }
@@ -625,22 +625,13 @@ UnresolvedJumpTable GenerateStaticTypeCheckBlocks(
     }
   }
 
-  // --- Reorder blocks ---
-  // Move dispatch + check + mro blocks to the front of basicblocks(),
-  // before the entry_block. This ensures the prologue falls through to
-  // the dispatch block.
-  auto& blocks = lir_func->basicblocks();
-
-  // Rotate the new blocks from the end to the front.
-  std::rotate(blocks.begin(), blocks.begin() + original_count, blocks.end());
-
   return result;
 }
 
 void GenerateArgcountCheckBlocks(
     Function* lir_func,
     const hir::Function* func,
-    BasicBlock* next_block,
+    asmjit::Label correct_args_label,
     asmjit::Label prologue_exit) {
   bool returns_primitive_double = func->returnsPrimitiveDouble();
   BorrowedRef<PyCodeObject> code = func->code;
@@ -657,8 +648,6 @@ void GenerateArgcountCheckBlocks(
   auto kwnames_reg = codegen::ARGUMENT_REGS[3];
   auto nargsf_reg = codegen::ARGUMENT_REGS[2];
 
-  int num_new_blocks = 0;
-
   if (will_check_argcount) {
     // Two blocks:
     //   kw_dispatch: test kwnames → if null, branch to argcount_check;
@@ -668,7 +657,6 @@ void GenerateArgcountCheckBlocks(
     //                   helper → exit.
     auto* kw_dispatch = lir_func->allocateBasicBlock();
     auto* argcount_check = lir_func->allocateBasicBlock();
-    num_new_blocks = 2;
 
     // --- kw_dispatch ---
     emitAnnotation(kw_dispatch, "Keyword argument dispatch");
@@ -710,8 +698,7 @@ void GenerateArgcountCheckBlocks(
         PhyReg{nargsf_reg, OperandBase::k32bit},
         PhyReg{kwnames_reg, OperandBase::k32bit});
     argcount_check->allocateInstr(
-        Instruction::kBranchE, nullptr, Lbl{next_block});
-    argcount_check->addSuccessor(next_block);
+        Instruction::kBranchE, nullptr, AsmLbl{correct_args_label});
 
     // Wrong argcount: kwnames_reg already holds numArgs for the 4th arg.
     auto helper = returns_primitive_double
@@ -725,7 +712,6 @@ void GenerateArgcountCheckBlocks(
     // have_varargs or kwonlyargcount > 0: always dispatch through the
     // keyword helper (it handles *args, **kwargs, keyword-only args, etc.).
     auto* kw_dispatch = lir_func->allocateBasicBlock();
-    num_new_blocks = 1;
 
     emitAnnotation(kw_dispatch, "Keyword argument dispatch (varargs/kwonly)");
 
@@ -736,13 +722,6 @@ void GenerateArgcountCheckBlocks(
     kw_dispatch->allocateInstr(
         Instruction::kBranch, nullptr, AsmLbl{prologue_exit});
   }
-
-  // Rotate the new blocks from the end to the front.
-  auto& blocks = lir_func->basicblocks();
-  std::rotate(
-      blocks.begin(),
-      blocks.end() - static_cast<std::ptrdiff_t>(num_new_blocks),
-      blocks.end());
 }
 
 void GenerateFunctionEntryBlock(Function* lir_func) {
@@ -750,10 +729,6 @@ void GenerateFunctionEntryBlock(Function* lir_func) {
 
   // No annotation needed — translatePrologue adds "Set up frame pointer".
   block->allocateInstr(Instruction::kPrologue, nullptr);
-
-  // Rotate the new block to the front.
-  auto& blocks = lir_func->basicblocks();
-  std::rotate(blocks.begin(), blocks.end() - 1, blocks.end());
 }
 
 void GeneratePrimitiveArgsPrologueBlock(
@@ -791,10 +766,6 @@ void GeneratePrimitiveArgsPrologueBlock(
   // Since the original code unconditionally calls generateFunctionExit()
   // after the call, we branch to prologue_exit.
   block->allocateInstr(Instruction::kBranch, nullptr, AsmLbl{prologue_exit});
-
-  // Rotate the new block to the front.
-  auto& blocks = lir_func->basicblocks();
-  std::rotate(blocks.begin(), blocks.end() - 1, blocks.end());
 }
 
 void GenerateBoxedReturnWrapperBlocks(
@@ -936,10 +907,6 @@ void GenerateBoxedReturnWrapperBlocks(
 
   box_block->allocateInstr(Instruction::kCall, nullptr, Imm{box_func});
   box_block->allocateInstr(Instruction::kBranch, nullptr, AsmLbl{wrapper_exit});
-
-  // Rotate the two new blocks to the front.
-  auto& blocks = lir_func->basicblocks();
-  std::rotate(blocks.begin(), blocks.end() - 2, blocks.end());
 }
 
 void LIRGenerator::GenerateExitBlocks() {

--- a/cinderx/Jit/lir/generator.cpp
+++ b/cinderx/Jit/lir/generator.cpp
@@ -1203,10 +1203,9 @@ std::unique_ptr<jit::lir::Function> LIRGenerator::TranslateFunction() {
   // dispatches to resume targets via indirect jump (populated post-regalloc
   // by PopulateResumeEntryBlock). Its successors are the resume blocks,
   // which keeps them reachable during sortBasicBlocks.
-  // We always create this for generators because translateYieldInitial
-  // references gen_resume_entry_label (the label bound to this block).
-  // On pre-3.12, kYieldInitial is monolithic and doesn't add to
-  // resume_blocks_, but still needs the resume entry block to exist.
+  // We always create this for generators because the codegen for
+  // kStoreGenYieldPoint references gen_resume_entry_label (the label
+  // bound to this block).
   if (is_gen_) {
     auto* resume_entry = lir_func_->allocateBasicBlock();
     // Remove from basic_blocks_ immediately — this is a placeholder block
@@ -2318,18 +2317,16 @@ LIRGenerator::TranslatedBlock LIRGenerator::TranslateOneBasicBlock(
       }
       case Opcode::kInitialYield: {
         auto hir_instr = static_cast<const InitialYield*>(&i);
-        // 3.12+: decompose kYieldInitial into setup + branch + resume.
-        // kYieldInitial does the setup and store yield point but does NOT
-        // emit the jmp or bind the resume label.
-        Instruction* instr =
-            bbb.appendInstr(Instruction::kYieldInitial, env_->asm_tstate);
-        finishYield(bbb, instr, hir_instr);
 
-        // Capture the gen object from the return register into a vreg.
-        Instruction* gen_obj = bbb.appendInstr(
+        // Unlink the generator frame and get the gen object back.
+        Instruction* gen_obj = bbb.appendCallInstruction(
             OutVReg{},
-            Instruction::kBind,
-            PhyReg{codegen::arch::reg_general_return_loc});
+            JITRT_UnlinkGenFrameAndReturnGenDataFooter,
+            env_->asm_tstate);
+
+        // Store yield point metadata (same as kYieldValue).
+        Instruction* store = bbb.appendInstr(Instruction::kStoreGenYieldPoint);
+        finishYield(bbb, store, hir_instr);
 
         // kBranchToYieldExit: terminates this block.
         auto* branch = bbb.appendInstr(Instruction::kBranchToYieldExit);

--- a/cinderx/Jit/lir/generator.cpp
+++ b/cinderx/Jit/lir/generator.cpp
@@ -4036,6 +4036,7 @@ LIRGenerator::TranslatedBlock LIRGenerator::TranslateOneBasicBlock(
             Ind{callee_frame,
                 (Py_ssize_t)offsetof(FrameHeader, func) -
                     (Py_ssize_t)sizeof(FrameHeader)});
+
         JIT_DCHECK(
             JIT_FRAME_INITIALIZED == 2,
             "JIT_FRAME_INITIALIZED changed"); // this is the bit we're testing
@@ -4043,7 +4044,16 @@ LIRGenerator::TranslatedBlock LIRGenerator::TranslateOneBasicBlock(
         bbb.appendInstr(Instruction::kBitTest, rtfs_reg, Imm{1});
         auto done_block = bbb.allocateBlock();
         auto not_materialized_block = bbb.allocateBlock();
-        bbb.appendBranch(Instruction::kBranchNC, not_materialized_block);
+        // kBitTest lowers differently per architecture:
+        // - x86: BT sets the Carry flag to the tested bit value, so
+        //   kBranchNC (jnc) branches when the bit is NOT set.
+        // - ARM64: BT is lowered to TST which sets the Zero flag, so
+        //   kBranchE (b.eq) branches when the bit is NOT set.
+        bbb.appendBranch(
+            codegen::arch::kBuildArch == codegen::arch::Arch::kAarch64
+                ? Instruction::kBranchE
+                : Instruction::kBranchNC,
+            not_materialized_block);
         bbb.appendBlock(bbb.allocateBlock());
 
         // The frame was materialized, let's use the unlink helper to clean

--- a/cinderx/Jit/lir/generator.h
+++ b/cinderx/Jit/lir/generator.h
@@ -259,13 +259,18 @@ struct UnresolvedJumpTable {
   void** table{nullptr};
   // Maps table index → LIR BasicBlock* target.
   std::vector<std::pair<int, BasicBlock*>> entries;
+  // The dispatch block that should receive the correct_arg_count label.
+  BasicBlock* dispatch_block{nullptr};
 };
 
 // Build post-regalloc LIR blocks for validating that arguments passed to a
 // Static Python function via the generic (vectorcall) entry point have the
 // correct types. Creates a dispatch block + per-argument check blocks (with
-// optional MRO walk blocks) and inserts them at the front of the LIR function's
-// block list so the prologue falls through to the dispatch block.
+// optional MRO walk blocks). The blocks are appended to the block list; the
+// caller is responsible for positioning them.
+//
+// entry_block is the branch target for successful type checks (typically the
+// entry block with arg loading).
 //
 // Returns an UnresolvedJumpTable whose entries must be resolved after code
 // generation (when block labels have been bound to addresses).
@@ -279,15 +284,15 @@ UnresolvedJumpTable GenerateStaticTypeCheckBlocks(
 
 // Build a post-regalloc LIR block for the function entry prologue
 // (push rbp; mov rbp, rsp on x86-64 / stp fp, lr; mov fp, sp on aarch64).
-// The block is inserted at the front of the LIR function's block list so the
-// vectorcall entry falls through to it.
+// The block is appended to the block list; the caller is responsible for
+// positioning it.
 void GenerateFunctionEntryBlock(Function* lir_func);
 
 // Build a post-regalloc LIR block for the primitive-args prologue.
 // Loads the _PyTypedArgsInfo pointer into the 5th argument register (R8/x4),
 // calls JITRT_CallStaticallyWithPrimitiveSignature[FP], then branches to
-// prologue_exit. The block is inserted at the front of the LIR function's
-// block list.
+// prologue_exit. The block is appended to the block list; the caller is
+// responsible for positioning it.
 void GeneratePrimitiveArgsPrologueBlock(
     Function* lir_func,
     PyObject* prim_args_info,
@@ -296,13 +301,13 @@ void GeneratePrimitiveArgsPrologueBlock(
 
 // Build post-regalloc LIR blocks for the vectorcall argcount check prologue.
 // Handles three paths: kwnames present (call keyword helper), wrong argcount
-// (call incorrect-argcount helper), correct argcount (fall through to
-// next_block). The created blocks are inserted at the front of the LIR
-// function's block list so the vectorcall entry falls through to them.
+// (call incorrect-argcount helper), correct argcount (branch to
+// correct_args_label). The blocks are appended to the block list; the caller
+// is responsible for positioning them.
 void GenerateArgcountCheckBlocks(
     Function* lir_func,
     const hir::Function* func,
-    BasicBlock* next_block,
+    asmjit::Label correct_args_label,
     asmjit::Label prologue_exit);
 
 // Build post-regalloc LIR blocks for the boxed-return wrapper that converts
@@ -310,8 +315,9 @@ void GenerateArgcountCheckBlocks(
 // sets up its own minimal frame, calls the inner function via generic_entry,
 // checks the success flag (EDX/W1 for integers, XMM1/D1 for doubles), boxes
 // the result by calling the appropriate JITRT_Box* helper, then branches to
-// wrapper_exit (which should be bound to a leave;ret sequence). The created
-// blocks are inserted at the front of the LIR function's block list.
+// wrapper_exit (which should be bound to a leave;ret sequence). The blocks
+// are appended to the block list; the caller is responsible for positioning
+// them.
 void GenerateBoxedReturnWrapperBlocks(
     Function* lir_func,
     hir::Type return_type,

--- a/cinderx/Jit/lir/instruction.cpp
+++ b/cinderx/Jit/lir/instruction.cpp
@@ -292,7 +292,6 @@ bool Instruction::isTerminator() const {
 
 bool Instruction::isAnyYield() const {
   switch (opcode_) {
-    case kYieldInitial:
     case kStoreGenYieldPoint:
     case kStoreGenYieldFromPoint:
       return true;

--- a/cinderx/Jit/lir/instruction.h
+++ b/cinderx/Jit/lir/instruction.h
@@ -171,7 +171,6 @@ enum OperandSizeType {
   X(MovSXD)                                                                   \
   X(IntToBool, false, FlagEffects::kSet, kDefault, 1, {1})                    \
   X(LoadThreadState, false, FlagEffects::kInvalidate, kDefault, 0, {}, 0)     \
-  X(YieldInitial, false, FlagEffects::kInvalidate, kDefault, 0, {}, 1)        \
   X(StoreGenYieldPoint, false, FlagEffects::kInvalidate, kDefault, 0, {}, 1)  \
   X(StoreGenYieldFromPoint,                                                   \
     false,                                                                    \

--- a/cinderx/Jit/lir/operand.cpp
+++ b/cinderx/Jit/lir/operand.cpp
@@ -84,7 +84,7 @@ OperandBase* MemoryIndirect::getIndexRegOperand() const {
   return index_reg_.get();
 }
 
-uint8_t MemoryIndirect::getMultipiler() const {
+uint8_t MemoryIndirect::getMultiplier() const {
   return multiplier_;
 }
 

--- a/cinderx/Jit/lir/operand.h
+++ b/cinderx/Jit/lir/operand.h
@@ -109,7 +109,7 @@ class MemoryIndirect {
   OperandBase* getBaseRegOperand() const;
   OperandBase* getIndexRegOperand() const;
 
-  uint8_t getMultipiler() const;
+  uint8_t getMultiplier() const;
   int32_t getOffset() const;
 
  private:

--- a/cinderx/Jit/lir/postalloc.cpp
+++ b/cinderx/Jit/lir/postalloc.cpp
@@ -905,7 +905,6 @@ RewriteResult rewriteMemoryInputsToReg(instr_iter_t instr_iter) {
     case Instruction::kMovSX:
     case Instruction::kMovSXD:
     case Instruction::kLoadThreadState:
-    case Instruction::kYieldInitial:
     case Instruction::kStoreGenYieldPoint:
     case Instruction::kStoreGenYieldFromPoint:
     case Instruction::kBranchToYieldExit:

--- a/cinderx/Jit/lir/postgen.cpp
+++ b/cinderx/Jit/lir/postgen.cpp
@@ -592,7 +592,7 @@ RewriteResult rewriteLeaLargeMultiplier(instr_iter_t instr_iter) {
     return kUnchanged;
   }
 
-  auto mult = ind->getMultipiler();
+  auto mult = ind->getMultiplier();
   if (mult < 4) {
     return kUnchanged;
   }

--- a/cinderx/Jit/lir/printer.cpp
+++ b/cinderx/Jit/lir/printer.cpp
@@ -146,7 +146,7 @@ void Printer::print(std::ostream& out, const MemoryIndirect& ind) {
   if (index_reg != nullptr) {
     fmt::print(out, " + {}", *index_reg);
 
-    int multiplier = ind.getMultipiler();
+    int multiplier = ind.getMultiplier();
     if (multiplier > 0) {
       fmt::print(out, " * {}", 1 << multiplier);
     }

--- a/cinderx/Jit/lir/regalloc.cpp
+++ b/cinderx/Jit/lir/regalloc.cpp
@@ -1234,7 +1234,7 @@ void LinearScanAllocator::rewriteInstrOneIndirectOperand(
   indirect->setMemoryIndirect(
       base_phy_reg,
       index_phy_reg,
-      indirect->getMultipiler(),
+      indirect->getMultiplier(),
       indirect->getOffset());
 
   if (base_last_use) {

--- a/cinderx/Jit/lir/regalloc.cpp
+++ b/cinderx/Jit/lir/regalloc.cpp
@@ -293,14 +293,6 @@ int LinearScanAllocator::getFrameSize() const {
   return -max_stack_slot_;
 }
 
-int LinearScanAllocator::initialYieldSpillSize() const {
-  JIT_CHECK(
-      initial_yield_spill_size_ != -1,
-      "Don't have InitialYield spill size yet");
-
-  return initial_yield_spill_size_;
-}
-
 bool LinearScanAllocator::isPredefinedUsed(const Operand* operand) const {
   auto& block = func_->basicblocks()[0];
 
@@ -594,22 +586,6 @@ void LinearScanAllocator::calculateLiveIntervals() {
 
 void LinearScanAllocator::spillRegistersForYield(int instr_id) {
   reserveRegisters(instr_id, INIT_REGISTERS);
-}
-
-void LinearScanAllocator::computeInitialYieldSpillSize(
-    const UnorderedMap<const Operand*, const LiveInterval*>& mapping) {
-  JIT_CHECK(
-      initial_yield_spill_size_ == -1,
-      "Already computed InitialYield spill size");
-
-  for (auto& pair : mapping) {
-    const LiveInterval* interval = pair.second;
-    if (interval->allocated_loc.is_register()) {
-      continue;
-    }
-    initial_yield_spill_size_ =
-        std::max(initial_yield_spill_size_, -interval->allocated_loc.loc);
-  }
 }
 
 void LinearScanAllocator::reserveCallerSaveRegisters(int instr_id) {
@@ -1111,9 +1087,6 @@ void LinearScanAllocator::rewriteLIR() {
 
           if (instr->output()->isInd()) {
             rewriteInstrOutput(instr, mapping, &last_use_vregs);
-          }
-          if (instr->isYieldInitial()) {
-            computeInitialYieldSpillSize(mapping);
           }
         }
       } else {

--- a/cinderx/Jit/lir/regalloc.h
+++ b/cinderx/Jit/lir/regalloc.h
@@ -109,8 +109,6 @@ class LinearScanAllocator {
   // Return the number of bytes that should be allocated below the base pointer.
   int getFrameSize() const;
 
-  int initialYieldSpillSize() const;
-
   // returns true if the variables defined in the entry block is
   // used in the function.
   bool isPredefinedUsed(const Operand* operand) const;
@@ -142,8 +140,6 @@ class LinearScanAllocator {
   void calculateLiveIntervals();
 
   void spillRegistersForYield(int instr_id);
-  void computeInitialYieldSpillSize(
-      const UnorderedMap<const Operand*, const LiveInterval*>& mapping);
 
   // Reserve all caller-saved registers for a function call.
   void reserveCallerSaveRegisters(int instr_id);
@@ -273,7 +269,6 @@ class LinearScanAllocator {
   std::vector<PhyLocation> free_stack_slots_;
 
   codegen::PhyRegisterSet changed_regs_;
-  int initial_yield_spill_size_{-1};
 
   // record vreg-to-physical-location mapping at the end of each basic block,
   // which is needed for resolve edges.

--- a/cinderx/ParallelGC/parallel_gc.c
+++ b/cinderx/ParallelGC/parallel_gc.c
@@ -1151,16 +1151,16 @@ static int Ci_should_use_par_gc(Ci_ParGCState* par_gc, int gen);
 
 /* This is the main function.  Read this to understand how the
  * collection process works. */
-#if PY_VERSION_HEX < 0x030F0000
-static Py_ssize_t
-#else
+#ifdef ENABLE_INCREMENTAL_GC
 static void
+#else
+static Py_ssize_t
 #endif
 gc_collect_main(
     struct Ci_PyGCImpl* gc_impl,
     PyThreadState* tstate,
     int generation,
-#if PY_VERSION_HEX >= 0x030F0000
+#ifdef ENABLE_INCREMENTAL_GC
     struct gc_generation_stats* stats) {
 #elif PY_VERSION_HEX >= 0x030E0000
     _PyGC_Reason reason) {
@@ -1366,7 +1366,7 @@ gc_collect_main(
   }
 
   assert(!_PyErr_Occurred(tstate));
-#if PY_VERSION_HEX < 0x030F0000
+#ifndef ENABLE_INCREMENTAL_GC
   return n + m;
 #endif
 }

--- a/cinderx/PythonLib/test_cinderx/test_cinderjit.py
+++ b/cinderx/PythonLib/test_cinderx/test_cinderjit.py
@@ -30,12 +30,10 @@ from cinderx.test_support import (
     passUnless,
     run_in_subprocess,
     skip_if_ft,
-    skip_module_if_oss,
     skip_unless_jit,
     subprocess_env,
 )
 
-skip_module_if_oss()
 
 from cinderx.compiler.consts import CO_SUPPRESS_JIT
 

--- a/cinderx/RuntimeTests/lir_abi_test.cpp
+++ b/cinderx/RuntimeTests/lir_abi_test.cpp
@@ -88,10 +88,6 @@ class LIRABITest : public RuntimeTest {
         environ.block_label_map.emplace(deopt_bb, as.newLabel());
         break;
       }
-      case Instruction::kYieldInitial:
-        environ.code_rt->addDeoptMetadata(DeoptMetadata{});
-        environ.initial_yield_spill_size_ = 16;
-        break;
       default:
         break;
     }
@@ -1299,22 +1295,6 @@ TEST_F(LIRABITest, TestkBitTest_PhyReg_PhyReg) {
   translateInstr(Instruction::kBitTest, makePhyReg(0), Imm{63});
 }
 
-// kYieldInitial ANY
-TEST_F(LIRABITest, TestkYieldInitial) {
-  PyCodeObject code;
-  hir::FrameState frameState(BorrowedRef(&code), nullptr, nullptr, nullptr);
-
-  hir::Register out(0);
-  auto origin = std::unique_ptr<hir::InitialYield>(
-      hir::InitialYield::create(&out, frameState));
-
-  auto tstate = makeStk(-16);
-  auto live_regs = Imm{0};
-  auto deopt_idx = Imm{0};
-
-  translateInstrWithOrigin(
-      Instruction::kYieldInitial, origin.get(), tstate, live_regs, deopt_idx);
-}
 // kSelect R r r r
 TEST_F(LIRABITest, TestkSelect_OutPhyReg_PhyReg_PhyReg_PhyReg) {
 #if defined(CINDER_X86_64)

--- a/setup.py
+++ b/setup.py
@@ -488,7 +488,6 @@ class BuildExt(build_ext):
         include_dir = sysconfig.get_path("include")
         return os.path.join(include_dir, "..", "..")
 
-
 def main() -> None:
     setup(
         name="cinderx",


### PR DESCRIPTION
This is to address the removal of `skip_oss` within the cinderx codebase. Instead of doing everything at once I am going to remove in chunk this is the first iteration of this. 