### PR TITLE
Fix fmtlib build error

### DIFF
--- a/cinderx/Jit/hir/hir.h
+++ b/cinderx/Jit/hir/hir.h
@@ -547,6 +547,10 @@ enum class BinaryOpKind {
 #undef DEFINE_OP
 };
 
+inline auto format_as(BinaryOpKind kind) {
+  return fmt::underlying(kind);
+}
+
 #define COUNT_OP(NAME) +1
 constexpr size_t kNumBinaryOpKinds = FOREACH_BINARY_OP_KIND(COUNT_OP);
 #undef COUNT_OP


### PR DESCRIPTION
Added a log for BinaryOpKind but there's no format implementation for it yet.