### PR TITLE
Add abortImpl() helper

### DIFF
--- a/cinderx/Common/log.cpp
+++ b/cinderx/Common/log.cpp
@@ -34,4 +34,11 @@ std::string repr(BorrowedRef<> obj) {
   return {str, static_cast<std::string::size_type>(len)};
 }
 
+void abortImpl() {
+  fmt::print(stderr, "\n");
+  std::fflush(stderr);
+  jit::printPythonException();
+  std::abort();
+}
+
 } // namespace jit

--- a/cinderx/Common/log.h
+++ b/cinderx/Common/log.h
@@ -81,13 +81,13 @@ std::string repr(BorrowedRef<> obj);
     JIT_ABORT_IMPL(__VA_ARGS__);                                     \
   }
 
+// Continuation of JIT_ABORT_IMPL(), but out-of-line.
+[[noreturn]] void abortImpl();
+
 #define JIT_ABORT_IMPL(...)          \
   {                                  \
     fmt::print(stderr, __VA_ARGS__); \
-    fmt::print(stderr, "\n");        \
-    std::fflush(stderr);             \
-    jit::printPythonException();     \
-    std::abort();                    \
+    jit::abortImpl();                \
   }
 
 #ifdef Py_DEBUG


### PR DESCRIPTION
Takes 4 function calls and folds them down to 1.  These functions are never expected to fire, but we end up sprinkling many instances of them around every time we use JIT_CHECK().