### PR TITLE
Remove Skip OSS for Parallel GC

### DIFF
--- a/cinderx/PythonLib/test_cinderx/test_parallel_gc.py
+++ b/cinderx/PythonLib/test_cinderx/test_parallel_gc.py
@@ -6,12 +6,13 @@ import unittest
 
 import cinderx
 import cinderx.jit
-from cinderx.test_support import passIf, passUnless, skip_module_if_oss
+from cinderx.test_support import is_oss, passIf, passUnless
 
-skip_module_if_oss()
-
-# pyre-ignore[21]: Pyre doesn't know about cpython/Lib/test.
-import test.test_gc
+if is_oss():
+    test_gc_module = None
+else:
+    # pyre-ignore[21]: Pyre doesn't know about cpython/Lib/test.
+    import test.test_gc as test_gc_module
 
 
 def _restore_parallel_gc(settings: dict[str, int] | None) -> None:
@@ -56,39 +57,40 @@ class ParallelGCAPITests(unittest.TestCase):
 # Run all the GC tests with parallel GC enabled
 
 
-@passUnless(cinderx.has_parallel_gc(), "Testing the Parallel GC")
-# pyre-ignore[11]: Pyre doesn't know about cpython/Lib/test.
-class ParallelGCTests(test.test_gc.GCTests):
-    @passIf(cinderx.jit.is_enabled(), "Implementation detail of the interpreter")
-    def test_frame(self) -> None:
-        pass
+if test_gc_module is not None:
 
-    @passIf(cinderx.jit.is_enabled(), "Implementation detail of the interpreter")
-    def test_get_objects_arguments(self) -> None:
-        pass
-
-
-if cinderx.has_parallel_gc():
+    @passUnless(cinderx.has_parallel_gc(), "Testing the Parallel GC")
     # pyre-ignore[11]: Pyre doesn't know about cpython/Lib/test.
-    class ParallelGCCallbackTests(test.test_gc.GCCallbackTests):
-        # Tests implementation details of serial collector
-        def test_refcount_errors(self) -> None:
-            # necessary for tearDown to succeed
-            # pyre-ignore[16]: ParallelGCCallbackTests` has no attribute `visit`
-            self.visit = None
+    class ParallelGCTests(test_gc_module.GCTests):
+        @passIf(cinderx.jit.is_enabled(), "Implementation detail of the interpreter")
+        def test_frame(self) -> None:
+            pass
 
+        @passIf(cinderx.jit.is_enabled(), "Implementation detail of the interpreter")
+        def test_get_objects_arguments(self) -> None:
+            pass
 
-@passUnless(cinderx.has_parallel_gc(), "Testing the Parallel GC")
-# pyre-ignore[11]: Pyre doesn't know about cpython/Lib/test.
-class ParallelGCFinalizationTests(test.test_gc.PythonFinalizationTests):
-    pass
+    if cinderx.has_parallel_gc():
+        # pyre-ignore[11]: Pyre doesn't know about cpython/Lib/test.
+        class ParallelGCCallbackTests(test_gc_module.GCCallbackTests):
+            # Tests implementation details of serial collector
+            def test_refcount_errors(self) -> None:
+                # necessary for tearDown to succeed
+                # pyre-ignore[16]: ParallelGCCallbackTests` has no attribute `visit`
+                self.visit = None
+
+    @passUnless(cinderx.has_parallel_gc(), "Testing the Parallel GC")
+    # pyre-ignore[11]: Pyre doesn't know about cpython/Lib/test.
+    class ParallelGCFinalizationTests(test_gc_module.PythonFinalizationTests):
+        pass
 
 
 OLD_PAR_GC_SETTINGS: dict[str, int] | None = None
 
 
 def setUpModule() -> None:
-    test.test_gc.setUpModule()
+    if test_gc_module is not None:
+        test_gc_module.setUpModule()
 
     global OLD_PAR_GC_SETTINGS
     OLD_PAR_GC_SETTINGS = cinderx.get_parallel_gc_settings()
@@ -100,7 +102,8 @@ def setUpModule() -> None:
 
 
 def tearDownModule() -> None:
-    test.test_gc.tearDownModule()
+    if test_gc_module is not None:
+        test_gc_module.tearDownModule()
 
     _restore_parallel_gc(OLD_PAR_GC_SETTINGS)
 


### PR DESCRIPTION
This diff is apart of the larger effort to enable more tests for cinderx in open source. This one in particular is to remove `skip_oss` for par gc. The only caveat which I mention on the comment below is that I made the `test.test_gc` conditional because that seemed to be an internal specific import