### PR TITLE
Get all Static Python tests passing

### DIFF
--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/compile.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/compile.py
@@ -23,7 +23,6 @@ from unittest import skip
 from unittest.mock import patch
 
 import cinderx.jit
-import xxclassloader
 from cinderx import install_frame_evaluator, StrictModule
 from cinderx.compiler.consts import CI_CO_STATICALLY_COMPILED
 from cinderx.compiler.pycodegen import PythonCodeGenerator
@@ -37,7 +36,7 @@ from cinderx.compiler.static.types import (
     TypeEnvironment,
     Value,
 )
-from cinderx.test_support import passIf, passUnless, skip_unless_jit, subprocess_env
+from cinderx.test_support import passIf, passUnless, skip_test_if_oss, skip_unless_jit, subprocess_env
 
 from .common import (
     add_fixed_module,
@@ -65,6 +64,9 @@ def optional(type: str) -> str:
 
 
 def init_xxclassloader():
+    # Lazily imported here, can fail on OSS builds.
+    import xxclassloader
+
     codestr = """
         from typing import Generic, TypeVar, _tp_cache
         from __static__ import set_type_static
@@ -108,7 +110,6 @@ def init_xxclassloader():
     d = {"<builtins>": builtins.__dict__}
     add_fixed_module(d)
 
-    install_frame_evaluator()
     exec(code, d, d)
 
     # pyrefly: ignore [missing-attribute]
@@ -118,13 +119,25 @@ def init_xxclassloader():
 class StaticCompilationTests(StaticTestBase):
     @classmethod
     def setUpClass(cls):
-        init_xxclassloader()
+        install_frame_evaluator()
+
+        try:
+            init_xxclassloader()
+        except ImportError:
+            pass
+
         cls.type_env = TypeEnvironment()
 
     @classmethod
     def tearDownClass(cls):
-        # pyrefly: ignore [missing-attribute]
-        del xxclassloader.XXGeneric
+        # Already imported by init_xxclassloader(), this should just create the
+        # local binding.  Unless it's OSS and xxclassloader is not available.
+        try:
+            import xxclassloader
+            # pyrefly: ignore [missing-attribute]
+            del xxclassloader.XXGeneric
+        except ImportError:
+            pass
 
     def test_static_import_unknown(self) -> None:
         codestr = """
@@ -1889,6 +1902,7 @@ class StaticCompilationTests(StaticTestBase):
             C = mod.C
             self.assertEqual(C().g(), 42)
 
+    @skip_test_if_oss("Uses xxclassloader")
     def test_multi_generic(self) -> None:
         codestr = """
         from xxclassloader import XXGeneric
@@ -4592,6 +4606,7 @@ class StaticCompilationTests(StaticTestBase):
         ):
             self.compile(codestr)
 
+    @skip_test_if_oss("Uses xxclassloader")
     def test_spamobj_no_params(self) -> None:
         codestr = """
             from xxclassloader import spamobj
@@ -4706,6 +4721,7 @@ class StaticCompilationTests(StaticTestBase):
             f = mod.myfunc
             self.assertNotInBytecode(f, "LOAD_FIELD")
 
+    @skip_test_if_oss("Uses xxclassloader")
     def test_generic_optional_type_param(self) -> None:
         codestr = """
             from xxclassloader import spamobj
@@ -4717,6 +4733,7 @@ class StaticCompilationTests(StaticTestBase):
 
         self.compile(codestr)
 
+    @skip_test_if_oss("Uses xxclassloader")
     def test_generic_optional_type_param_2(self) -> None:
         codestr = """
             from xxclassloader import spamobj

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/elide_type_checks.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/elide_type_checks.py
@@ -2,12 +2,13 @@
 from __static__ import StaticTypeError
 
 import cinderx.jit
-from cinderx.test_support import skip_unless_jit
+from cinderx.test_support import skip_test_if_oss, skip_unless_jit
 
 from .common import StaticTestBase
 
 
 class ElideTypeChecksTests(StaticTestBase):
+    @skip_test_if_oss("Uses xxclassloader")
     @skip_unless_jit("Testing Static Python + JIT behavior")
     def test_invoke_function_skips_arg_type_checks(self) -> None:
         codestr = """
@@ -48,6 +49,7 @@ class ElideTypeChecksTests(StaticTestBase):
             # but only because we are using an unsound C extension method.
             self.assertEqual(mod.f(), "B")
 
+    @skip_test_if_oss("Uses xxclassloader")
     @skip_unless_jit("Testing Static Python + JIT behavior")
     def test_invoke_method_skips_arg_type_checks(self) -> None:
         codestr = """

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/patch.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/patch.py
@@ -1,4 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+
 import asyncio
 import re
 import sys
@@ -10,8 +11,8 @@ try:
 except ImportError:
     getknobs = setknobs = None
 
-import xxclassloader
 from cinderx.compiler.pycodegen import PythonCodeGenerator
+from cinderx.test_support import skip_test_if_oss
 
 from .common import StaticTestBase
 
@@ -2167,6 +2168,7 @@ class StaticPatchTests(StaticTestBase):
 
             self.assertEqual(asyncio.run(awaiter(mod.C())), 131)
 
+    @skip_test_if_oss("Uses xxclassloader")
     def test_thunk_traversal(self) -> None:
         codestr = """
             def f():
@@ -2184,6 +2186,7 @@ class StaticPatchTests(StaticTestBase):
             self.assertEqual(g(), 100)
 
             # This triggers a traversal of the thunk using its tp_traverse
+            import xxclassloader
             xxclassloader.traverse_heap()
 
     def test_patch_staticmethod(self) -> None:


### PR DESCRIPTION
All of the issues are centered around importing xxclassloader, which isn't available on OSS builds.  Import it lazily to avoid test listing issues, and skip the specific tests that are trying to use it.