### PR TITLE
Get the JIT working on macOS

### DIFF
--- a/cinderx/Jit/code_allocator.cpp
+++ b/cinderx/Jit/code_allocator.cpp
@@ -13,6 +13,13 @@
 #include <sys/mman.h>
 #endif
 
+#ifdef __APPLE__
+#include <pthread.h>
+#ifdef __aarch64__
+#include <libkern/OSCacheControl.h>
+#endif
+#endif
+
 #include <cstring>
 
 namespace jit {
@@ -30,14 +37,34 @@ namespace {
 // 2MiB to match Linux's huge-page size.
 constexpr size_t kAllocSize = 1024 * 1024 * 2;
 
+// On macOS ARM64, MAP_JIT memory requires toggling between writable and
+// executable states per-thread via pthread_jit_write_protect_np.
+void jitEnableWriting() {
+#if defined(__APPLE__) && defined(__aarch64__)
+  pthread_jit_write_protect_np(0);
+#endif
+}
+
+void jitEnableExecuting(
+    [[maybe_unused]] void* addr, [[maybe_unused]] size_t size) {
+#if defined(__APPLE__) && defined(__aarch64__)
+  pthread_jit_write_protect_np(1);
+  sys_icache_invalidate(addr, size);
+#endif
+}
+
 // Allocate memory for JIT'd code.
 uint8_t* allocPages(size_t size) {
 #ifndef WIN32
+  int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+#ifdef __APPLE__
+  flags |= MAP_JIT;
+#endif
   void* res = mmap(
       nullptr,
       size,
       PROT_EXEC | PROT_READ | PROT_WRITE,
-      MAP_PRIVATE | MAP_ANONYMOUS,
+      flags,
       -1,
       0);
   JIT_CHECK(
@@ -247,6 +274,7 @@ AllocateResult CodeAllocatorCinder::addSplitCode(asmjit::CodeHolder* code) {
 
   // Copy each section's data to the appropriate allocation.
   size_t total_size = 0;
+  jitEnableWriting();
   for (asmjit::Section* section : code->_sections) {
     size_t buffer_size = section->bufferSize();
     if (buffer_size == 0) {
@@ -264,6 +292,7 @@ AllocateResult CodeAllocatorCinder::addSplitCode(asmjit::CodeHolder* code) {
     }
     total_size += buffer_size;
   }
+  jitEnableExecuting(addr, total_size);
 
   used_bytes_.fetch_add(total_size, std::memory_order_relaxed);
   return AllocateResult{addr, asmjit::kErrorOk};
@@ -287,6 +316,7 @@ AllocateResult CodeAllocatorCinder::addCode(asmjit::CodeHolder* code) {
   size_t actual_code_size = code->codeSize();
   JIT_CHECK(actual_code_size <= max_code_size, "Code grew during relocation");
 
+  jitEnableWriting();
   for (asmjit::Section* section : code->_sections) {
     size_t offset = section->offset();
     size_t buffer_size = section->bufferSize();
@@ -305,6 +335,7 @@ AllocateResult CodeAllocatorCinder::addCode(asmjit::CodeHolder* code) {
   }
 
   void* addr = hot_alloc_;
+  jitEnableExecuting(addr, actual_code_size);
 
   hot_alloc_ += actual_code_size;
   hot_alloc_free_ -= actual_code_size;

--- a/cinderx/StaticPython/vtable_defs.c
+++ b/cinderx/StaticPython/vtable_defs.c
@@ -679,6 +679,13 @@ StaticMethodInfo _PyVTable_load_generic(PyObject* state, PyObject* self) {
   return return_to_native_typecode(obj, sig->ta_rettype);
 }
 
+// macOS prefixes all C symbols with an underscore.
+#ifdef __APPLE__
+#define THUNK_NATIVE_NAME "__PyVTable_thunk_native"
+#else
+#define THUNK_NATIVE_NAME "_PyVTable_thunk_native"
+#endif
+
 #if defined(_M_X64) || defined(_M_AMD64) || defined(__x86_64__)
 #ifdef _WIN32
 __attribute__((naked))
@@ -707,7 +714,7 @@ PyObject* _PyVTable_native_entry(PyObject* state, void** args) {
       "mov %rsp, %r8\n"
       /* Allocate shadow space for the call */
       "sub $32, %rsp\n"
-      "call _PyVTable_thunk_native\n"
+      "call " THUNK_NATIVE_NAME "\n"
       /* Restore the struct return values into RAX/RDX to match the */
       /* JIT's native calling convention (RAX:RDX pair like SysV) */
       "mov -16(%rbp), %rax\n"
@@ -739,7 +746,7 @@ PyObject* _PyVTable_native_entry(PyObject* state, void** args) {
       "push %rdx\n"
       "push %rsi\n"
       "mov %rsp, %rsi\n"
-      "call _PyVTable_thunk_native\n"
+      "call " THUNK_NATIVE_NAME "\n"
       /* We don't know if we're returning a floating point value or not */
       /* so we assume we are, and always populate the xmm registers */
       /* even if we don't need to */
@@ -770,7 +777,7 @@ PyObject* _PyVTable_native_entry(PyObject* state, void** args) {
       "stp x7, x9, [sp, #48]\n"
       /* Set x1 to point to the args array */
       "mov x1, sp\n"
-      "bl _PyVTable_thunk_native\n"
+      "bl " THUNK_NATIVE_NAME "\n"
       /* We don't know if we're returning a floating point value or not */
       /* so we assume we are, and always populate the FP registers */
       /* even if we don't need to */


### PR DESCRIPTION
Needs two changes - fixing the symbol of the Static Python native thunk, and supporting W^X memory permissions.