### PR TITLE
removing skip_module_if_oss

### DIFF
--- a/cinderx/PythonLib/test_cinderx/test_coro_extensions.py
+++ b/cinderx/PythonLib/test_cinderx/test_coro_extensions.py
@@ -6,12 +6,20 @@ import types
 import unittest
 from collections.abc import AsyncGenerator, Callable, Coroutine, Generator, Iterator
 
-from cinderx.test_support import hasCinderX, passIf, skip_if_jit, skip_module_if_oss
+from cinderx.test_support import hasCinderX, passIf, skip_if_jit, is_oss
 
-skip_module_if_oss()
 
-# pyre-ignore[21]: can't find test.support
-from test.support import import_helper, maybe_get_event_loop_policy
+
+if is_oss():
+    import importlib
+    import asyncio.events
+    def event_policy_wrapper():
+        return  asyncio.events._event_loop_policy  
+    maybe_get_event_loop_policy = event_policy_wrapper
+    import_helper = importlib
+else:
+    # pyre-ignore[21]: can't find test.support
+    from test.support import import_helper, maybe_get_event_loop_policy
 
 
 if hasCinderX():


### PR DESCRIPTION
Diff to remove `skip_module_if_oss`  in `cinderx/PythonLib/test_cinderx/test_coro_extensions.py`. the main issue was the import of specific test modules that are for internal use. I mainly just created a simple OSS version of those functions because looking at the source code of those test util functions it was fairly easy re-create. I think doing these functions add adhoc is fine because there is no other overlap between the import of these functions and the usage of skip_module_if_oss