### PR TITLE
Only enable LTO on Linux right now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ build = [
     "cp314-macosx_arm64",
     "cp314-win_amd64",
 ]
-environment = { CINDERX_ENABLE_PGO = "1", CINDERX_ENABLE_LTO = "1" }
+environment = { CINDERX_ENABLE_PGO = "1" }
+# If it exists, pass through CINDERX_VERSION_PATCH to setuptools to specify the
+# patch version.
+environment-pass = ["CINDERX_VERSION_PATCH"]
 build-verbosity = 3
 # Build using the latest image to try to get the latest Python point release.
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28:latest"
@@ -52,14 +55,9 @@ test-requires = ["pytest"]
 test-command = "pytest {project}/cinderx/PythonLib/test_cinderx/test*.py"
 
 [tool.cibuildwheel.linux]
-# If it exists, pass through CINDERX_VERSION_PATCH to setuptools to specify the
-# patch version.
-environment-pass = ["CINDERX_VERSION_PATCH"]
+# LTO is Linux-only in CMakeLists.txt right now.
+environment = { CINDERX_ENABLE_PGO = "1", CINDERX_ENABLE_LTO = "1" }
 
 [tool.cibuildwheel.macos]
-environment-pass = ["CINDERX_VERSION_PATCH"]
-# Only build for arm64 (aarch64) on macOS
+# Not building for macOS x86-64.
 archs = ["arm64"]
-
-[tool.cibuildwheel.windows]
-environment-pass = ["CINDERX_VERSION_PATCH"]


### PR DESCRIPTION
macOS wheels are failing to build because CMakeLists.txt gets unhappy with macOS and LTO right now.