### PR TITLE
Disable PGO for macOS and Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ build = [
     "cp314-macosx_arm64",
     "cp314-win_amd64",
 ]
-environment = { CINDERX_ENABLE_PGO = "1" }
 # If it exists, pass through CINDERX_VERSION_PATCH to setuptools to specify the
 # patch version.
 environment-pass = ["CINDERX_VERSION_PATCH"]


### PR DESCRIPTION
Our setup.py and CMakeLists.txt are still too Linux-minded and they're now failing our publish workflow on macOS because llvm-profdata can't be found. I'm betting there's something not right with Windows right now either.

Disable PGO on macOS and Windows to unblock publishing, we'll come back and fix this later.