### PR TITLE
Don't glob in cibuildwheel command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ musllinux-x86_64-image = "quay.io/pypa/musllinux_1_2:latest"
 manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64:latest"
 musllinux-aarch64-image = "quay.io/pypa/musllinux_1_2_aarch64:latest"
 test-requires = ["pytest"]
-test-command = "pytest {project}/cinderx/PythonLib/test_cinderx/test*.py"
+test-command = "pytest {project}/cinderx/PythonLib/test_cinderx/ --ignore={project}/cinderx/PythonLib/test_cinderx/test_cpython_overrides/test__opcode.py"
 
 [tool.cibuildwheel.linux]
 # LTO is Linux-only in CMakeLists.txt right now.


### PR DESCRIPTION
Windows is unhappy with it.  Plus this makes the cibuildwheel test command match what ci.yml does.