### PR TITLE
Fix remaining warnings in tests

### DIFF
--- a/cinderx/PythonLib/test_cinderx/test_cinderjit.py
+++ b/cinderx/PythonLib/test_cinderx/test_cinderjit.py
@@ -9,6 +9,7 @@ import tempfile
 import textwrap
 import traceback
 import unittest
+import warnings
 import weakref
 from pathlib import Path
 from typing import Callable, TYPE_CHECKING
@@ -47,7 +48,7 @@ else:
     StaticTestBase = unittest.TestCase
 
 
-class TestException(Exception):
+class ExampleException(Exception):
     pass
 
 
@@ -2081,10 +2082,10 @@ class StoreSubscrTests(unittest.TestCase):
     def test_store_subscr_deopts_on_exception(self) -> None:
         class C:
             def __setitem__(self, key, value):
-                raise TestException("hello")
+                raise ExampleException("hello")
 
         obj = C()
-        with self.assertRaisesRegex(TestException, "hello"):
+        with self.assertRaisesRegex(ExampleException, "hello"):
             self.doit(obj, 1, 2)
 
 
@@ -2112,9 +2113,9 @@ class FormatValueTests(unittest.TestCase):
     def test_format_value_calls_str_with_exception(self) -> None:
         class C:
             def __str__(self):
-                raise TestException("no")
+                raise ExampleException("no")
 
-        with self.assertRaisesRegex(TestException, "no"):
+        with self.assertRaisesRegex(ExampleException, "no"):
             self.doit(C())
 
     def test_format_value_calls_repr(self) -> None:
@@ -2127,9 +2128,9 @@ class FormatValueTests(unittest.TestCase):
     def test_format_value_calls_repr_with_exception(self) -> None:
         class C:
             def __repr__(self):
-                raise TestException("no")
+                raise ExampleException("no")
 
-        with self.assertRaisesRegex(TestException, "no"):
+        with self.assertRaisesRegex(ExampleException, "no"):
             self.doit_repr(C())
 
 
@@ -2238,15 +2239,15 @@ class ListToTupleTests(unittest.TestCase):
 class CompareTests(unittest.TestCase):
     class Incomparable:
         def __lt__(self, other):
-            raise TestException("no lt")
+            raise ExampleException("no lt")
 
     class NonIterable:
         def __iter__(self):
-            raise TestException("no iter")
+            raise ExampleException("no iter")
 
     class NonIndexable:
         def __getitem__(self, idx):
-            raise TestException("no getitem")
+            raise ExampleException("no getitem")
 
     @cinder_support.failUnlessJITCompiled
     @failUnlessHasOpcodes("COMPARE_OP")
@@ -2276,21 +2277,21 @@ class CompareTests(unittest.TestCase):
     def test_compare_op(self) -> None:
         self.assertTrue(self.compare_op(3, 4))
         self.assertFalse(self.compare_op(3, 3))
-        with self.assertRaisesRegex(TestException, "no lt"):
+        with self.assertRaisesRegex(ExampleException, "no lt"):
             self.compare_op(self.Incomparable(), 123)
 
     def test_contains_op(self) -> None:
         self.assertTrue(self.compare_in(3, [1, 2, 3]))
         self.assertFalse(self.compare_in(4, [1, 2, 3]))
-        with self.assertRaisesRegex(TestException, "no iter"):
+        with self.assertRaisesRegex(ExampleException, "no iter"):
             self.compare_in(123, self.NonIterable())
-        with self.assertRaisesRegex(TestException, "no getitem"):
+        with self.assertRaisesRegex(ExampleException, "no getitem"):
             self.compare_in(123, self.NonIndexable())
         self.assertTrue(self.compare_not_in(4, [1, 2, 3]))
         self.assertFalse(self.compare_not_in(3, [1, 2, 3]))
-        with self.assertRaisesRegex(TestException, "no iter"):
+        with self.assertRaisesRegex(ExampleException, "no iter"):
             self.compare_not_in(123, self.NonIterable())
-        with self.assertRaisesRegex(TestException, "no getitem"):
+        with self.assertRaisesRegex(ExampleException, "no getitem"):
             self.compare_not_in(123, self.NonIndexable())
 
     def test_is_op(self) -> None:
@@ -2748,15 +2749,19 @@ class CompileTimeTests(unittest.TestCase):
     """
 
     def test_compile_time(self) -> None:
-        # This function is known to have a lengthy compile time.
-        try:
-            # pyre-ignore[21]: Pyre doesn't know about this function.
-            from sre_compile import _compile
-        except ImportError:
-            # sre_compile was removed in 3.15, re._compiler is the same func
-            # as it was before.
-            # pyre-ignore[21]: Pyre doesn't know about this function.
-            from re._compiler import _compile
+        # sre_compile is deprecated.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+            # This function is known to have a lengthy compile time.
+            try:
+                # pyre-ignore[21]: Pyre doesn't know about this function.
+                from sre_compile import _compile
+            except ImportError:
+                # sre_compile was removed in 3.15, re._compiler is the same func
+                # as it was before.
+                # pyre-ignore[21]: Pyre doesn't know about this function.
+                from re._compiler import _compile
 
         # It's probably already compiled as part of regular startup, but just in case
         # let's make sure.

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_code_sbs.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_code_sbs.py
@@ -80,7 +80,7 @@ def graph_instrs(graph, name=None) -> Generator[Instruction, None, None]:
         yield from block.getInstructions()
 
 
-class TestFile:
+class ParsedTestFile:
     """Parsed test case file."""
 
     _SECTION_HEADERS = {SCRIPT_EXPECTED: "expected", SCRIPT_EXC_TABLE: "exc_table"}
@@ -352,7 +352,7 @@ def add_test(modname: str, fname: str) -> None:
         return
 
     def test_code(self: CodeTests) -> None:
-        test = TestFile(fname)
+        test = ParsedTestFile(fname)
         graph = self.to_graph(test.code)
 
         fixme = "fixup to be a minimal repro and check it in"

--- a/cinderx/PythonLib/test_cinderx/test_coro_extensions.py
+++ b/cinderx/PythonLib/test_cinderx/test_coro_extensions.py
@@ -1,29 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # pyre-strict
 
+import asyncio
 import sys
 import types
 import unittest
 from collections.abc import AsyncGenerator, Callable, Coroutine, Generator, Iterator
 
 from cinderx.test_support import hasCinderX, is_oss, passIf, skip_if_jit
-
-if is_oss():
-    import asyncio.events
-    import importlib
-
-    def event_policy_wrapper():
-        return asyncio.events._event_loop_policy
-
-    maybe_get_event_loop_policy = event_policy_wrapper
-    import_helper = importlib
-else:
-    # pyre-ignore[21]: can't find test.support
-    from test.support import import_helper, maybe_get_event_loop_policy
-
-
-if hasCinderX():
-    import cinder
 
 
 def run_async(
@@ -43,11 +27,6 @@ def run_async(
 
 
 class TestEagerExecution(unittest.TestCase):
-    def setUp(self) -> None:
-        self._asyncio = import_helper.import_module("asyncio")
-        policy = maybe_get_event_loop_policy()
-        self.addCleanup(lambda: self._asyncio.set_event_loop_policy(policy))
-
     async def _raise_IndexError_eager(self, x: object = None) -> None:
         try:
             raise IndexError
@@ -58,7 +37,7 @@ class TestEagerExecution(unittest.TestCase):
         try:
             raise IndexError
         except:  # noqa B001
-            await self._asyncio.sleep(0)
+            await asyncio.sleep(0)
 
     def _check(
         self,
@@ -67,7 +46,7 @@ class TestEagerExecution(unittest.TestCase):
     ) -> None:
         def run(coro: Coroutine[object, None, object]) -> type[BaseException] | None:
             try:
-                self._asyncio.run(coro)
+                asyncio.run(coro)
                 self.fail("Exception expected")
             except RuntimeError as e:
                 if e.__context__ is None:


### PR DESCRIPTION
Things that are named `TestFoo` are assumed to be test fixtures by `pytest`.  Some of these aren't test fixtures.

We can assume `asyncio` exists.