### PR TITLE
Fix cinderx/PythonLib/test_cinderx/test_compiler/tests.py

### DIFF
--- a/cinderx/PythonLib/test_cinderx/test_compiler/tests.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/tests.py
@@ -8,15 +8,12 @@ from .test_api import ApiTests
 from .test_code_sbs import CodeTests
 from .test_errors import ErrorTests, ErrorTestsBuiltin
 
-# pyre-ignore[21]: test_exceptiontable not found (not included in buck test build)
-from .test_exceptiontable import EncodingTests
+from .test_exception_table import EncodingTests
 from .test_flags import FlagTests
 from .test_graph import GraphTests
 from .test_linepos import LinePositionTests
 from .test_optimizer import AstOptimizerTests
 
-# pyre-ignore[21]: test_peephole not found (not included in buck test build)
-from .test_peephole import PeepHoleTests
 from .test_symbols import SymbolVisitorTests
 from .test_unparse import UnparseTests
 from .test_visitor import VisitorTests


### PR DESCRIPTION
test_exception_table.py was misspelled, and test_peephole.py does not exist.