### PR TITLE
Add 3.14.5 to OSS CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         # Test against multiple patch versions as CinderX references internal
         # CPython functions and structures which can lead to ABI problems.  See
         # cinderx/UpstreamBorrow for more details.
-        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3', '3.14.4']
+        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3', '3.14.4', '3.14.5']
 
     steps:
     - name: Checkout CinderX


### PR DESCRIPTION
Adds Python 3.14.5 to the CI test matrix