### PR TITLE
Add the building of macOS and Windows wheels in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       # Don't let build failures on one platform block other platforms.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
 
     steps:
       - name: Checkout CinderX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,23 +81,32 @@ if(ENABLE_LTO)
     message(FATAL_ERROR "LTO is only supported with Clang, GCC, or MSVC compilers")
   endif()
 
-  # For Clang, we need llvm-ar instead of regular ar.  On macOS, try to find
-  # llvm-ar, but it's optional as the system ar may work with AppleClang's LTO.
+  # For Clang LTO we need an LLVM archiver.  Use llvm-lib on Windows (clang-cl
+  # wants MSVC-style /flags, which llvm-ar rejects), and llvm-ar elsewhere.
+  # Both are optional on macOS since AppleClang may work with the system ar.
   if(USING_CLANG)
-    find_program(LLVM_AR llvm-ar)
-    if(LLVM_AR)
-      set(CMAKE_AR ${LLVM_AR})
-      message(STATUS "LTO: Using llvm-ar: ${CMAKE_AR}")
-    elseif(MACOS)
-      message(STATUS
-        "LTO: Using system ar (llvm-ar not found,"
-        " AppleClang may work with system ar)")
-    elseif(WINDOWS)
-      message(STATUS
-        "LTO: Using system lib (llvm-ar not found, Clang-CL may work with"
-        " system lib)")
+    if(WINDOWS)
+      find_program(LLVM_LIB llvm-lib)
+      if(LLVM_LIB)
+        set(CMAKE_AR ${LLVM_LIB})
+        message(STATUS "LTO: Using llvm-lib: ${CMAKE_AR}")
+      else()
+        message(STATUS
+          "LTO: Using system lib (llvm-lib not found, Clang-CL may work with"
+          " system lib)")
+      endif()
     else()
-      message(FATAL_ERROR "llvm-ar is required for LTO with Clang but was not found")
+      find_program(LLVM_AR llvm-ar)
+      if(LLVM_AR)
+        set(CMAKE_AR ${LLVM_AR})
+        message(STATUS "LTO: Using llvm-ar: ${CMAKE_AR}")
+      elseif(MACOS)
+        message(STATUS
+          "LTO: Using system ar (llvm-ar not found,"
+          " AppleClang may work with system ar)")
+      else()
+        message(FATAL_ERROR "llvm-ar is required for LTO with Clang but was not found")
+      endif()
     endif()
 
     # Use ThinLTO on macOS for better performance and lower memory usage.

--- a/setup.py
+++ b/setup.py
@@ -226,6 +226,16 @@ if __name__ == "__main__":
             print_section("PGO STAGE 2b: Merging profile data")
 
             llvm_profdata = shutil.which("llvm-profdata")
+            if not llvm_profdata and sys.platform == "darwin":
+                # Apple Clang ships llvm-profdata in the Xcode toolchain but
+                # doesn't put it on PATH; locate it via xcrun.
+                result = subprocess.run(
+                    ["xcrun", "-f", "llvm-profdata"],
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    llvm_profdata = result.stdout.strip()
             if not llvm_profdata:
                 raise RuntimeError("Cannot find llvm-profdata")
             glob_path = os.path.join(clang_pgo_dir, "*.profraw")


### PR DESCRIPTION
Make macOS and Windows wheels be built (in addition to Linux - currently existing) when pull requests are created.

Note that we don't run tests on the Windows wheels, mirroring that of the Windows CI workflow (tests aren't run there either). 