### PR TITLE
Add CI for CinderX + Free-Threaded Python 3.14 on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,18 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v7
 
+    # Ubuntu's default GCC 13.3 hits an internal compiler error on
+    # SwapLockGuard's std::atomic_ref::compare_exchange_weak in
+    # cinderx/Jit/code_patcher.cpp, which is only compiled under
+    # Py_GIL_DISABLED. GCC 14 (which is also what manylinux_2_28
+    # ships via gcc-toolset-14) compiles it cleanly.
+    - name: Install GCC 14
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-14 g++-14
+        echo "CC=gcc-14" >> "$GITHUB_ENV"
+        echo "CXX=g++-14" >> "$GITHUB_ENV"
+
     - name: Create venv
       run: uv venv --python ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,47 @@ jobs:
     - name: Run Tests
       run: uv run pytest cinderx/PythonLib/test_cinderx/
 
+  run_tests_ft:
+    name: Run Tests (Free-Threaded)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Free-threaded Python 3.14 (3.14t) is only covered on Linux for now.
+        # macOS and Windows FT coverage is intentionally out of scope.
+        python-version: ['3.14t']
+
+    steps:
+    - name: Checkout CinderX
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Create venv
+      run: uv venv --python ${{ matrix.python-version }}
+
+    - name: Build CinderX
+      run: uv build --wheel --python ${{ matrix.python-version }}
+
+    - name: Install CinderX
+      run: uv pip install cinderx --find-links dist --no-index
+
+    - name: Check CinderX loads successfully
+      run: |
+        uv run python -c 'import cinderx ; print(cinderx.get_import_error()) ; assert cinderx.is_initialized()'
+
+    - name: Install pytest
+      run: uv pip install pytest
+
+    - name: Run Tests
+      run: uv run pytest cinderx/PythonLib/test_cinderx/
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,11 @@ endif()
 # UpstreamBorrow/
 
 if (${PY_VERSION} EQUAL 3.12 OR ${PY_VERSION} EQUAL 3.14 OR ${PY_VERSION} EQUAL 3.15)
-  set(BORROWED_C ${PROJECT_SOURCE_DIR}/UpstreamBorrow/borrowed-${PY_VERSION}.gen_cached.c)
+  if (ENABLE_FREE_THREADING AND EXISTS ${PROJECT_SOURCE_DIR}/UpstreamBorrow/borrowed-${PY_VERSION}.free-threading.gen_cached.c)
+    set(BORROWED_C ${PROJECT_SOURCE_DIR}/UpstreamBorrow/borrowed-${PY_VERSION}.free-threading.gen_cached.c)
+  else()
+    set(BORROWED_C ${PROJECT_SOURCE_DIR}/UpstreamBorrow/borrowed-${PY_VERSION}.gen_cached.c)
+  endif()
 else()
   set(BORROWED_C "${GENERATED_HEADER_DIR}/dummy-borrowed.c")
   file(WRITE ${BORROWED_C} "")

--- a/cinderx/Jit/jit_rt.cpp
+++ b/cinderx/Jit/jit_rt.cpp
@@ -2160,16 +2160,19 @@ PyObject JITRT_IterDoneSentinel = {
     .ob_gc_bits = _PyGC_BITS_DEFERRED,
     .ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL,
     .ob_ref_shared = 0,
+    .ob_type = nullptr,
 #else
     {.ob_refcnt = _Py_IMMORTAL_INITIAL_REFCNT,
      .ob_flags = _Py_STATIC_FLAG_BITS},
+    nullptr,
 #endif
 // clang-format on
 
 #else
     {.ob_refcnt = _Py_IMMORTAL_REFCNT},
+    nullptr,
 #endif
-    nullptr};
+};
 
 PyObject* JITRT_InvokeIterNext(PyObject* iterator) {
   iternextfunc iternext_f = Py_TYPE(iterator)->tp_iternext;

--- a/cinderx/UpstreamBorrow/borrowed-3.14.free-threading.c.template
+++ b/cinderx/UpstreamBorrow/borrowed-3.14.free-threading.c.template
@@ -612,8 +612,10 @@ LONG_FLOAT_ACTION(compactlong_float_true_div, /)
 #undef Py_XNewRef
 #define Py_XNewRef(obj) _Py_XNewRef(_PyObject_CAST(obj))
 
+#ifdef Py_REF_DEBUG
 // @Borrow optional function reftotal_add from Objects/object.c
 // @Borrow optional function _Py_AddRefTotal from Objects/object.c
+#endif
 // @Borrow function _Py_ExplicitMergeRefcount from Objects/object.c
 // @Borrow function _Py_qsbr_advance from Python/qsbr.c
 // @Borrow function _Py_qsbr_shared_next from Python/qsbr.c

--- a/cinderx/UpstreamBorrow/borrowed-3.14.free-threading.gen_cached.c
+++ b/cinderx/UpstreamBorrow/borrowed-3.14.free-threading.gen_cached.c
@@ -7881,6 +7881,7 @@ struct _mem_work_chunk {
 #undef Py_XNewRef
 #define Py_XNewRef(obj) _Py_XNewRef(_PyObject_CAST(obj))
 
+#ifdef Py_REF_DEBUG
 static inline void
 reftotal_add(PyThreadState *tstate, Py_ssize_t n)
 {
@@ -7898,6 +7899,7 @@ _Py_AddRefTotal(PyThreadState *tstate, Py_ssize_t n)
 {
     reftotal_add(tstate, n);
 }
+#endif  // Py_REF_DEBUG
 Py_ssize_t
 _Py_ExplicitMergeRefcount(PyObject *op, Py_ssize_t extra)
 {

--- a/setup.py
+++ b/setup.py
@@ -436,8 +436,10 @@ class BuildExt(build_ext):
         mac = sys.platform == "darwin"
         meta_312 = meta_python and py_version == "3.12"
         is_314plus = py_version == "3.14" or py_version == "3.15"
+        free_threading = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
         set_option("META_PYTHON", meta_python)
+        set_option("ENABLE_FREE_THREADING", free_threading)
         set_option("ENABLE_ADAPTIVE_STATIC_PYTHON", meta_312)
         set_option("ENABLE_DISASSEMBLER", True)
         set_option("ENABLE_ELF_READER", linux)


### PR DESCRIPTION
Adds a new run_tests_ft job that builds and runs the CinderX pytest suite against the free-threaded build of Python 3.14 (3.14t) on ubuntu-latest.

Per T268241452, FT coverage on macOS and Windows is intentionally out of scope for now. Tests that don't yet work with free-threading are already gated via cinderx.test_support.skip_if_ft.

Test Plan: Triggered by pushing this branch; the new job runs alongside the existing run_tests matrix.