### PR TITLE
Add OSS build support for cinderx/RuntimeTests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,49 +63,33 @@ jobs:
     - name: Run Tests
       run: uv run pytest cinderx/PythonLib/test_cinderx/
 
-  run_native_tests:
-    name: Run Native Tests (C++)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # Don't let test failures on one platform block other platforms.
-      fail-fast: false
-      matrix:
-        # TODO(T269778952): add Windows once native CMake tests can link
-        # against CPython's MSVC import library cleanly.
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        # Match run_tests because RuntimeTests embeds CPython directly.
-        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3', '3.14.4', '3.14.5']
+    - name: Install native test build tools
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
+      run: uv pip install ninja cmake
 
-    # Keep CMake flag parsing consistent across runners.
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    - name: Checkout CinderX
-      uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install build tools
-      run: python -m pip install --upgrade pip ninja cmake
-
-    - name: Configure CMake
+    - name: Configure native tests
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
       run: |
-        cmake \
+        uv run cmake \
           -S . \
           -B build \
           -G Ninja \
           -DBUILD_RUNTIME_TESTS=ON \
+          -DENABLE_DISASSEMBLER=ON \
+          -DENABLE_INTERPRETER_LOOP=ON \
+          -DENABLE_PEP523_HOOK=ON \
+          -DENABLE_ZLIB=ON \
+          -DENABLE_ELF_READER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
+          -DENABLE_SYMBOLIZER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
+          -DENABLE_USDT=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
           -DPY_VERSION=3.14
 
-    - name: Build
-      run: cmake --build build -j
+    - name: Build native tests
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
+      run: uv run cmake --build build -j
 
-    - name: Run ctest
+    - name: Run native tests
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
       # Skip known OSS-only failures. Keep these narrow so RuntimeTests still
       # provide useful signal.
       # TODO(T269778952): burn these down as the underlying issues are fixed.
@@ -113,7 +97,7 @@ jobs:
         set -euo pipefail
         common='AllPassesTest.*:AllPassesStaticTest.*:CmdLineTest.ExplicitJITDisable:UtilTest.SymbolizerResolvesDynamicSymbol'
         arm64='LIRGeneratorTest.ParserTest:BackendTest.MoveSequenceOpt2Test'
-        macos='SimplifyTest.BinaryOpWithObjSpecLeftAndRightFloatExactTurnsIntoLoadConst:NativeCallsTest.NativeInvokeBasic:SimplifyStaticTest.UnboxOfRandMaxIsEliminated:DeadCodeEliminationAndSimplifyTest.UnboxOfStaticGlobalIsOptimized:HIRBuilderStaticTest.CIntTypeEmitsConvertPrimitive:UtilTest.SymbolizerResolvesStaticSymbol:ElfTest.EmptyEntries:ElfTest.OneEntry:CodePatcherTest.DeoptPatch'
+        macos='SimplifyTest.BinaryOpWithObjSpecLeftAndRightFloatExactTurnsIntoLoadConst:NativeCallsTest.NativeInvokeBasic:SimplifyStaticTest.UnboxOfRandMaxIsEliminated:DeadCodeEliminationAndSimplifyTest.UnboxOfStaticGlobalIsOptimized:HIRBuilderStaticTest.CIntTypeEmitsConvertPrimitive:CodePatcherTest.DeoptPatch'
         filter="-${common}"
         if [[ "$RUNNER_ARCH" == "ARM64" ]]; then
           filter="${filter}:${arm64}"
@@ -122,7 +106,7 @@ jobs:
           filter="${filter}:${macos}"
         fi
         export GTEST_FILTER="$filter"
-        ctest --test-dir build --output-on-failure
+        uv run ctest --test-dir build --output-on-failure
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,15 @@ jobs:
     - name: Create venv
       run: uv venv --python ${{ matrix.python-version }}
 
+    - name: Install native test build tools
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
+      run: uv pip install ninja cmake
+
     - name: Build CinderX
+      # RuntimeTests do not support Windows or free-threaded builds yet.
+      env:
+        CINDERX_BUILD_RUNTIME_TESTS: ${{ runner.os != 'Windows' && matrix.python-version != '3.14t' && '1' || '' }}
+        CINDERX_RUNTIME_TESTS_OUTPUT_DIR: ${{ github.workspace }}/build/runtime-tests
       run: uv build --wheel --python ${{ matrix.python-version }}
 
     - name: Install CinderX
@@ -63,30 +71,6 @@ jobs:
     - name: Run Tests
       run: uv run pytest cinderx/PythonLib/test_cinderx/
 
-    - name: Install native test build tools
-      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
-      run: uv pip install ninja cmake
-
-    - name: Configure native tests
-      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
-      run: |
-        uv run cmake \
-          -S . \
-          -B build \
-          -G Ninja \
-          -DBUILD_RUNTIME_TESTS=ON \
-          -DENABLE_DISASSEMBLER=ON \
-          -DENABLE_INTERPRETER_LOOP=ON \
-          -DENABLE_PEP523_HOOK=ON \
-          -DENABLE_ZLIB=ON \
-          -DENABLE_ELF_READER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
-          -DENABLE_SYMBOLIZER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
-          -DENABLE_USDT=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
-          -DPY_VERSION=3.14
-
-    - name: Build native tests
-      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
-      run: uv run cmake --build build -j
 
     - name: Run native tests
       if: runner.os != 'Windows' && matrix.python-version != '3.14t'
@@ -105,8 +89,10 @@ jobs:
         if [[ "$RUNNER_OS" == "macOS" ]]; then
           filter="${filter}:${macos}"
         fi
+        package_parent="$(uv run python -c 'import pathlib, cinderx; print(pathlib.Path(cinderx.__file__).resolve().parent.parent)')"
+        export PYTHONPATH="$package_parent"
         export GTEST_FILTER="$filter"
-        uv run ctest --test-dir build --output-on-failure
+        (cd cinderx && ../build/runtime-tests/RuntimeTests)
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,67 @@ jobs:
     - name: Run Tests
       run: uv run pytest cinderx/PythonLib/test_cinderx/
 
+  run_native_tests:
+    name: Run Native Tests (C++)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Don't let test failures on one platform block other platforms.
+      fail-fast: false
+      matrix:
+        # TODO(T269778952): add Windows once native CMake tests can link
+        # against CPython's MSVC import library cleanly.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        # Match run_tests because RuntimeTests embeds CPython directly.
+        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3', '3.14.4', '3.14.5']
+
+    # Keep CMake flag parsing consistent across runners.
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout CinderX
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install build tools
+      run: python -m pip install --upgrade pip ninja cmake
+
+    - name: Configure CMake
+      run: |
+        cmake \
+          -S . \
+          -B build \
+          -G Ninja \
+          -DBUILD_RUNTIME_TESTS=ON \
+          -DPY_VERSION=3.14
+
+    - name: Build
+      run: cmake --build build -j
+
+    - name: Run ctest
+      # Skip known OSS-only failures. Keep these narrow so RuntimeTests still
+      # provide useful signal.
+      # TODO(T269778952): burn these down as the underlying issues are fixed.
+      run: |
+        set -euo pipefail
+        common='AllPassesTest.*:AllPassesStaticTest.*:CmdLineTest.ExplicitJITDisable:UtilTest.SymbolizerResolvesDynamicSymbol'
+        arm64='LIRGeneratorTest.ParserTest:BackendTest.MoveSequenceOpt2Test'
+        macos='SimplifyTest.BinaryOpWithObjSpecLeftAndRightFloatExactTurnsIntoLoadConst:NativeCallsTest.NativeInvokeBasic:SimplifyStaticTest.UnboxOfRandMaxIsEliminated:DeadCodeEliminationAndSimplifyTest.UnboxOfStaticGlobalIsOptimized:HIRBuilderStaticTest.CIntTypeEmitsConvertPrimitive:UtilTest.SymbolizerResolvesStaticSymbol:ElfTest.EmptyEntries:ElfTest.OneEntry:CodePatcherTest.DeoptPatch'
+        filter="-${common}"
+        if [[ "$RUNNER_ARCH" == "ARM64" ]]; then
+          filter="${filter}:${arm64}"
+        fi
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          filter="${filter}:${macos}"
+        fi
+        export GTEST_FILTER="$filter"
+        ctest --test-dir build --output-on-failure
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,16 @@ jobs:
       run: uv pip install ninja cmake
 
     - name: Build CinderX
-      run: uv build --wheel --python ${{ matrix.python-version }}
+      # RuntimeTests do not support Windows or free-threaded builds yet.
+      shell: bash
+      env:
+        CINDERX_BUILD_RUNTIME_TESTS: ${{ runner.os != 'Windows' && matrix.python-version != '3.14t' && '1' || '' }}
+        CINDERX_RUNTIME_TESTS_OUTPUT_DIR: ${{ github.workspace }}/build/runtime-tests
+      run: |
+        if [[ -n "${CINDERX_BUILD_RUNTIME_TESTS}" ]]; then
+          export CMAKE_BUILD_TYPE=
+        fi
+        uv build --wheel --python ${{ matrix.python-version }}
 
     - name: Install CinderX
       run: uv pip install cinderx --find-links dist --no-index
@@ -66,27 +75,6 @@ jobs:
 
     - name: Run Tests
       run: uv run pytest cinderx/PythonLib/test_cinderx/
-
-    - name: Configure native tests
-      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
-      run: |
-        uv run cmake \
-          -S . \
-          -B build \
-          -G Ninja \
-          -DBUILD_RUNTIME_TESTS=ON \
-          -DENABLE_DISASSEMBLER=ON \
-          -DENABLE_INTERPRETER_LOOP=ON \
-          -DENABLE_PEP523_HOOK=ON \
-          -DENABLE_ZLIB=ON \
-          -DENABLE_ELF_READER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
-          -DENABLE_SYMBOLIZER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
-          -DENABLE_USDT=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
-          -DPY_VERSION=3.14
-
-    - name: Build native tests
-      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
-      run: uv run cmake --build build -j
 
     - name: Run native tests
       if: runner.os != 'Windows' && matrix.python-version != '3.14t'
@@ -105,8 +93,10 @@ jobs:
         if [[ "$RUNNER_OS" == "macOS" ]]; then
           filter="${filter}:${macos}"
         fi
+        package_parent="$(uv run python -c 'import pathlib, cinderx; print(pathlib.Path(cinderx.__file__).resolve().parent.parent)')"
+        export PYTHONPATH="$package_parent"
         export GTEST_FILTER="$filter"
-        uv run ctest --test-dir build --output-on-failure
+        (cd cinderx && ../build/runtime-tests/RuntimeTests)
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,10 @@ jobs:
 
     - name: Build CinderX
       # RuntimeTests do not support Windows or free-threaded builds yet.
-      shell: bash
       env:
         CINDERX_BUILD_RUNTIME_TESTS: ${{ runner.os != 'Windows' && matrix.python-version != '3.14t' && '1' || '' }}
         CINDERX_RUNTIME_TESTS_OUTPUT_DIR: ${{ github.workspace }}/build/runtime-tests
-      run: |
-        if [[ -n "${CINDERX_BUILD_RUNTIME_TESTS}" ]]; then
-          export CMAKE_BUILD_TYPE=
-        fi
-        uv build --wheel --python ${{ matrix.python-version }}
+      run: uv build --wheel --python ${{ matrix.python-version }}
 
     - name: Install CinderX
       run: uv pip install cinderx --find-links dist --no-index
@@ -80,12 +75,13 @@ jobs:
       if: runner.os != 'Windows' && matrix.python-version != '3.14t'
       # Skip known OSS-only failures. Keep these narrow so RuntimeTests still
       # provide useful signal.
-      # TODO(T269778952): burn these down as the underlying issues are fixed.
+      # TODO(T275133043): burn these down as the underlying issues are fixed.
+      # Particularly the segfaults.
       run: |
         set -euo pipefail
         common='AllPassesTest.*:AllPassesStaticTest.*:CmdLineTest.ExplicitJITDisable:UtilTest.SymbolizerResolvesDynamicSymbol'
-        arm64='LIRGeneratorTest.ParserTest:BackendTest.MoveSequenceOpt2Test'
-        macos='SimplifyTest.BinaryOpWithObjSpecLeftAndRightFloatExactTurnsIntoLoadConst:NativeCallsTest.NativeInvokeBasic:SimplifyStaticTest.UnboxOfRandMaxIsEliminated:DeadCodeEliminationAndSimplifyTest.UnboxOfStaticGlobalIsOptimized:HIRBuilderStaticTest.CIntTypeEmitsConvertPrimitive:CodePatcherTest.DeoptPatch'
+        arm64='LIRGeneratorTest.ParserTest:BackendTest.MoveSequenceOpt2Test:CodePatcherTest.DeoptPatch:BranchRelaxationTest.*'
+        macos='BackendTest.CastTest:BackendTest.InlineJITRTCastTest:SimplifyTest.BinaryOpWithObjSpecLeftAndRightFloatExactTurnsIntoLoadConst:NativeCallsTest.NativeInvokeBasic:SimplifyStaticTest.UnboxOfRandMaxIsEliminated:DeadCodeEliminationAndSimplifyTest.UnboxOfStaticGlobalIsOptimized:HIRBuilderStaticTest.CIntTypeEmitsConvertPrimitive:CodePatcherTest.DeoptPatch'
         filter="-${common}"
         if [[ "$RUNNER_ARCH" == "ARM64" ]]; then
           filter="${filter}:${arm64}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,6 @@ jobs:
       run: uv pip install ninja cmake
 
     - name: Build CinderX
-      # RuntimeTests do not support Windows or free-threaded builds yet.
-      env:
-        CINDERX_BUILD_RUNTIME_TESTS: ${{ runner.os != 'Windows' && matrix.python-version != '3.14t' && '1' || '' }}
-        CINDERX_RUNTIME_TESTS_OUTPUT_DIR: ${{ github.workspace }}/build/runtime-tests
       run: uv build --wheel --python ${{ matrix.python-version }}
 
     - name: Install CinderX
@@ -71,6 +67,26 @@ jobs:
     - name: Run Tests
       run: uv run pytest cinderx/PythonLib/test_cinderx/
 
+    - name: Configure native tests
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
+      run: |
+        uv run cmake \
+          -S . \
+          -B build \
+          -G Ninja \
+          -DBUILD_RUNTIME_TESTS=ON \
+          -DENABLE_DISASSEMBLER=ON \
+          -DENABLE_INTERPRETER_LOOP=ON \
+          -DENABLE_PEP523_HOOK=ON \
+          -DENABLE_ZLIB=ON \
+          -DENABLE_ELF_READER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
+          -DENABLE_SYMBOLIZER=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
+          -DENABLE_USDT=$([[ "$RUNNER_OS" == "Linux" ]] && echo ON || echo OFF) \
+          -DPY_VERSION=3.14
+
+    - name: Build native tests
+      if: runner.os != 'Windows' && matrix.python-version != '3.14t'
+      run: uv run cmake --build build -j
 
     - name: Run native tests
       if: runner.os != 'Windows' && matrix.python-version != '3.14t'
@@ -89,10 +105,8 @@ jobs:
         if [[ "$RUNNER_OS" == "macOS" ]]; then
           filter="${filter}:${macos}"
         fi
-        package_parent="$(uv run python -c 'import pathlib, cinderx; print(pathlib.Path(cinderx.__file__).resolve().parent.parent)')"
-        export PYTHONPATH="$package_parent"
         export GTEST_FILTER="$filter"
-        (cd cinderx && ../build/runtime-tests/RuntimeTests)
+        uv run ctest --test-dir build --output-on-failure
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,25 +39,6 @@ else()
   set(CXX_FLAGS "-fvisibility-inlines-hidden")
 endif()
 
-function(default_bool_option NAME VALUE DOC)
-  if (NOT DEFINED ${NAME})
-    set(${NAME} ${VALUE} CACHE BOOL ${DOC})
-  endif()
-endfunction()
-
-if (BUILD_RUNTIME_TESTS)
-  default_bool_option(ENABLE_DISASSEMBLER ON "Enable disassembler support")
-  default_bool_option(ENABLE_INTERPRETER_LOOP ON "Enable CinderX interpreter loop")
-  default_bool_option(ENABLE_PEP523_HOOK ON "Enable PEP 523 frame-eval hook")
-  default_bool_option(ENABLE_ZLIB ON "Enable zlib support")
-
-  if (NOT MACOS AND NOT WINDOWS)
-    default_bool_option(ENABLE_ELF_READER ON "Enable ELF reader support")
-    default_bool_option(ENABLE_SYMBOLIZER ON "Enable symbolizer support")
-    default_bool_option(ENABLE_USDT ON "Enable USDT support")
-  endif()
-endif()
-
 macro(set_flag VAR)
   # Undefined feature flags should behave like OFF.
   if (${VAR})
@@ -452,9 +433,8 @@ add_library(parallel-gc ${PARALLEL_GC_SOURCES})
 ########################################
 # _cinderx.cpp
 
-set(SOURCES
+set(CINDERX_MODULE_LIB_SOURCES
   # Manually listed out to not accidentally include stuff in .git.
-  ${PROJECT_SOURCE_DIR}/_cinderx.cpp
   ${PROJECT_SOURCE_DIR}/_cinderx-lib.cpp
   ${PROJECT_SOURCE_DIR}/async_lazy_value.cpp
   ${PROJECT_SOURCE_DIR}/module_state.cpp
@@ -462,14 +442,20 @@ set(SOURCES
   ${PROJECT_SOURCE_DIR}/python_runtime.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED ${SOURCES})
-
+add_library(cinderx-lib STATIC ${CINDERX_MODULE_LIB_SOURCES})
 target_link_libraries(
-  ${PROJECT_NAME}
+  cinderx-lib
   PRIVATE
   Python::Module
   borrowed cached-properties common immortalize interpreter jit parallel-gc static-python
   asmjit::asmjit fmt::fmt)
+
+add_library(${PROJECT_NAME} SHARED ${PROJECT_SOURCE_DIR}/_cinderx.cpp)
+
+target_link_libraries(
+  ${PROJECT_NAME}
+  PRIVATE
+  cinderx-lib)
 
 # macOS doesn't allow depending on other shared libraries by default.
 if (${MACOS})
@@ -519,7 +505,6 @@ if (BUILD_RUNTIME_TESTS)
     ${PROJECT_SOURCE_DIR}/RuntimeTests/dataflow_test.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/deopt_patcher_test.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/deopt_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/elf_test.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/fixtures.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/gen_asm_test.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_analysis_test.cpp
@@ -552,22 +537,22 @@ if (BUILD_RUNTIME_TESTS)
     ${PROJECT_SOURCE_DIR}/RuntimeTests/slab_arena_test.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/testutil.cpp
     ${PROJECT_SOURCE_DIR}/RuntimeTests/type_profiler_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/util_test.cpp
-
-    # Provide _cinderx as a built-in module for the embedded interpreter.
-    ${PROJECT_SOURCE_DIR}/_cinderx-lib.cpp
-    ${PROJECT_SOURCE_DIR}/async_lazy_value.cpp
-    ${PROJECT_SOURCE_DIR}/module_c_state.cpp
-    ${PROJECT_SOURCE_DIR}/module_state.cpp
-    ${PROJECT_SOURCE_DIR}/python_runtime.cpp
   )
+
+  if (ENABLE_ELF_READER)
+    list(APPEND RUNTIME_TESTS_SOURCES ${PROJECT_SOURCE_DIR}/RuntimeTests/elf_test.cpp)
+  endif()
+
+  if (ENABLE_SYMBOLIZER)
+    list(APPEND RUNTIME_TESTS_SOURCES ${PROJECT_SOURCE_DIR}/RuntimeTests/util_test.cpp)
+  endif()
 
   add_executable(RuntimeTests ${RUNTIME_TESTS_SOURCES})
 
   target_link_libraries(
     RuntimeTests
     PRIVATE
-    borrowed cached-properties common immortalize interpreter jit parallel-gc static-python
+    cinderx-lib
     asmjit::asmjit fmt::fmt
     GTest::gtest
     Python::Python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,7 +471,7 @@ else()
 endif()
 
 ##############################################################################
-# RuntimeTests/ — opt-in C++ GoogleTest binary (T269778952).
+# RuntimeTests/ — opt-in C++ GoogleTest binary.
 
 if (BUILD_RUNTIME_TESTS)
   enable_testing()
@@ -489,62 +489,17 @@ if (BUILD_RUNTIME_TESTS)
   ########################################
   # RuntimeTests executable
 
-  set(RUNTIME_TESTS_SOURCES
-    # Match cinderx/RuntimeTests/BUCK srcs minus internal-only files.
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/alias_class_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/backend_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/bitvector_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/block_canonicalizer_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/branch_relaxation_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/bytecode_offsets_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/bytecode_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/code_allocator_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/cmdline_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/codegen_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/copy_graph_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/dataflow_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/deopt_patcher_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/deopt_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/fixtures.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/gen_asm_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_analysis_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_copy_propagation_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_frame_state_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_guard_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_insert_update_prev_instr_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_operand_type_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_parser_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_ssa_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_type_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/inline_cache_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/intrusive_list_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_context_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_flag_processor_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_list_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_time_log_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_abi_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_dce_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_inliner_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_postalloc_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_postgen_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_verify_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/main.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/ref_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/regalloc_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/sanity_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/slab_arena_test.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/testutil.cpp
-    ${PROJECT_SOURCE_DIR}/RuntimeTests/type_profiler_test.cpp
+  file(GLOB RUNTIME_TESTS_SOURCES
+    CONFIGURE_DEPENDS
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/*.cpp
   )
 
-  if (ENABLE_ELF_READER)
-    list(APPEND RUNTIME_TESTS_SOURCES ${PROJECT_SOURCE_DIR}/RuntimeTests/elf_test.cpp)
+  if (NOT ENABLE_ELF_READER)
+    list(REMOVE_ITEM RUNTIME_TESTS_SOURCES ${PROJECT_SOURCE_DIR}/RuntimeTests/elf_test.cpp)
   endif()
 
-  if (ENABLE_SYMBOLIZER)
-    list(APPEND RUNTIME_TESTS_SOURCES ${PROJECT_SOURCE_DIR}/RuntimeTests/util_test.cpp)
+  if (NOT ENABLE_SYMBOLIZER)
+    list(REMOVE_ITEM RUNTIME_TESTS_SOURCES ${PROJECT_SOURCE_DIR}/RuntimeTests/util_test.cpp)
   endif()
 
   add_executable(RuntimeTests ${RUNTIME_TESTS_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(ENABLE_PGO_GENERATE "Build with PGO profile generation" OFF)
 option(ENABLE_PGO_USE "Build with PGO profile use" OFF)
 set(PGO_PROFILE_FILE "" CACHE STRING "Path to PGO profile data")
 
+option(BUILD_RUNTIME_TESTS "Build the cinderx/RuntimeTests C++ GoogleTest binary" OFF)
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(MACOS 1)
   set(WINDOWS 0)
@@ -37,8 +39,28 @@ else()
   set(CXX_FLAGS "-fvisibility-inlines-hidden")
 endif()
 
+function(default_bool_option NAME VALUE DOC)
+  if (NOT DEFINED ${NAME})
+    set(${NAME} ${VALUE} CACHE BOOL ${DOC})
+  endif()
+endfunction()
+
+if (BUILD_RUNTIME_TESTS)
+  default_bool_option(ENABLE_DISASSEMBLER ON "Enable disassembler support")
+  default_bool_option(ENABLE_INTERPRETER_LOOP ON "Enable CinderX interpreter loop")
+  default_bool_option(ENABLE_PEP523_HOOK ON "Enable PEP 523 frame-eval hook")
+  default_bool_option(ENABLE_ZLIB ON "Enable zlib support")
+
+  if (NOT MACOS AND NOT WINDOWS)
+    default_bool_option(ENABLE_ELF_READER ON "Enable ELF reader support")
+    default_bool_option(ENABLE_SYMBOLIZER ON "Enable symbolizer support")
+    default_bool_option(ENABLE_USDT ON "Enable USDT support")
+  endif()
+endif()
+
 macro(set_flag VAR)
-  if (DEFINED ${VAR} AND ${${VAR}})
+  # Undefined feature flags should behave like OFF.
+  if (${VAR})
     set(SHARED_FLAGS "-D${VAR} ${SHARED_FLAGS}")
   endif()
 endmacro()
@@ -186,6 +208,11 @@ include(FetchContent)
 # python
 
 find_package(Python ${PY_VERSION} EXACT COMPONENTS Interpreter Development.Module REQUIRED)
+
+# RuntimeTests embeds Python, so it needs Python::Python.
+if (BUILD_RUNTIME_TESTS)
+  find_package(Python ${PY_VERSION} EXACT COMPONENTS Development.Embed REQUIRED)
+endif()
 
 # Some of our files are partially generated from CPython source, and they
 # expect to be able to include files relative to Include/internal.
@@ -455,4 +482,109 @@ if (WINDOWS)
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "_cinderx.pyd")
 else()
     set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "_cinderx.so")
+endif()
+
+##############################################################################
+# RuntimeTests/ — opt-in C++ GoogleTest binary (T269778952).
+
+if (BUILD_RUNTIME_TESTS)
+  enable_testing()
+
+  ########################################
+  # GoogleTest
+
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest
+    GIT_TAG v1.15.2 # 2024-Jul-31
+  )
+  FetchContent_MakeAvailable(googletest)
+
+  ########################################
+  # RuntimeTests executable
+
+  set(RUNTIME_TESTS_SOURCES
+    # Match cinderx/RuntimeTests/BUCK srcs minus internal-only files.
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/alias_class_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/backend_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/bitvector_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/block_canonicalizer_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/branch_relaxation_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/bytecode_offsets_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/bytecode_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/code_allocator_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/cmdline_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/codegen_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/copy_graph_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/dataflow_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/deopt_patcher_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/deopt_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/elf_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/fixtures.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/gen_asm_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_analysis_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_copy_propagation_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_frame_state_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_guard_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_insert_update_prev_instr_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_operand_type_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_parser_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_ssa_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/hir_type_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/inline_cache_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/intrusive_list_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_context_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_flag_processor_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_list_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/jit_time_log_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_abi_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_dce_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_inliner_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_postalloc_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_postgen_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/lir_verify_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/main.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/ref_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/regalloc_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/sanity_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/slab_arena_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/testutil.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/type_profiler_test.cpp
+    ${PROJECT_SOURCE_DIR}/RuntimeTests/util_test.cpp
+
+    # Provide _cinderx as a built-in module for the embedded interpreter.
+    ${PROJECT_SOURCE_DIR}/_cinderx-lib.cpp
+    ${PROJECT_SOURCE_DIR}/async_lazy_value.cpp
+    ${PROJECT_SOURCE_DIR}/module_c_state.cpp
+    ${PROJECT_SOURCE_DIR}/module_state.cpp
+    ${PROJECT_SOURCE_DIR}/python_runtime.cpp
+  )
+
+  add_executable(RuntimeTests ${RUNTIME_TESTS_SOURCES})
+
+  target_link_libraries(
+    RuntimeTests
+    PRIVATE
+    borrowed cached-properties common immortalize interpreter jit parallel-gc static-python
+    asmjit::asmjit fmt::fmt
+    GTest::gtest
+    Python::Python
+  )
+
+  target_compile_definitions(
+    RuntimeTests
+    PRIVATE
+    CINDERX_RUNTIME_TESTS_STATIC_CINDERX=1
+    # Used by RuntimeTest::SetUp() to import cinderx from PythonLib.
+    CINDERX_RUNTIME_TESTS_PYTHONPATH_PACKAGE=${PROJECT_SOURCE_DIR}/PythonLib
+  )
+
+  add_test(
+    NAME RuntimeTests
+    COMMAND RuntimeTests
+    # RuntimeTests open source-tree test data relative to cwd.
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  )
 endif()

--- a/cinderx/RuntimeTests/fixtures.h
+++ b/cinderx/RuntimeTests/fixtures.h
@@ -58,6 +58,10 @@ class RuntimeTest : public ::testing::Test {
     Py_Initialize();
     ASSERT_TRUE(Py_IsInitialized());
 
+    auto cinderx_mod = Ref<>::steal(PyImport_ImportModule("cinderx"));
+    ASSERT_NE(cinderx_mod, nullptr)
+        << "Could not import cinderx during test setup";
+
     auto mod_state = cinderx::getModuleState();
     ASSERT_NE(mod_state, nullptr) << "Could not load the CinderX module state, "
                                      "CinderX has not initialized properly";

--- a/cinderx/RuntimeTests/fixtures.h
+++ b/cinderx/RuntimeTests/fixtures.h
@@ -59,8 +59,8 @@ class RuntimeTest : public ::testing::Test {
     ASSERT_TRUE(Py_IsInitialized());
 
     auto cinderx_mod = Ref<>::steal(PyImport_ImportModule("cinderx"));
-    ASSERT_NE(cinderx_mod, nullptr)
-        << "Could not import cinderx during test setup";
+    JIT_CHECK(
+        cinderx_mod != nullptr, "Could not import cinderx during test setup");
 
     auto mod_state = cinderx::getModuleState();
     ASSERT_NE(mod_state, nullptr) << "Could not load the CinderX module state, "

--- a/cinderx/RuntimeTests/main.cpp
+++ b/cinderx/RuntimeTests/main.cpp
@@ -2,6 +2,17 @@
 
 #include <gtest/gtest.h>
 
+// Keep BUCK_BUILD as a synonym for the split RuntimeTests features so the
+// internal Buck target keeps its existing behavior.
+#ifdef BUCK_BUILD
+#ifndef CINDERX_RUNTIME_TESTS_USE_BUCK_RESOURCES
+#define CINDERX_RUNTIME_TESTS_USE_BUCK_RESOURCES 1
+#endif
+#ifndef CINDERX_RUNTIME_TESTS_STATIC_CINDERX
+#define CINDERX_RUNTIME_TESTS_STATIC_CINDERX 1
+#endif
+#endif
+
 #ifdef CINDERX_RUNTIME_TESTS_STATIC_CINDERX
 #include "cinderx/_cinderx-lib.h"
 #endif
@@ -27,10 +38,12 @@
 #endif
 
 #include <fmt/format.h>
+
 #include <sys/resource.h>
 
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 namespace {
 
@@ -160,10 +173,15 @@ void register_test(
   }
 }
 
+#define _QUOTE_HELPER(x) #x
+#define _QUOTE(x) _QUOTE_HELPER(x)
+
 #ifdef BAKED_IN_PYTHONPATH
-#define _QUOTE(x) #x
-#define QUOTE(x) _QUOTE(x)
-#define _BAKED_IN_PYTHONPATH QUOTE(BAKED_IN_PYTHONPATH)
+#define _BAKED_IN_PYTHONPATH _QUOTE(BAKED_IN_PYTHONPATH)
+#endif
+
+#ifdef CINDERX_RUNTIME_TESTS_PYTHONPATH_PACKAGE
+#define _CINDERX_RUNTIME_TESTS_PYTHONPATH_PACKAGE _QUOTE(CINDERX_RUNTIME_TESTS_PYTHONPATH_PACKAGE)
 #endif
 
 } // namespace
@@ -205,7 +223,11 @@ void registerCinderX() {
 }
 
 int main(int argc, char* argv[]) {
-#ifdef BAKED_IN_PYTHONPATH
+#ifdef CINDERX_RUNTIME_TESTS_PYTHONPATH_PACKAGE
+  // OSS path: point PYTHONPATH at the in-tree cinderx package so
+  // RuntimeTest::SetUp() can explicitly import cinderx after Py_Initialize().
+  setenv("PYTHONPATH", _CINDERX_RUNTIME_TESTS_PYTHONPATH_PACKAGE, 1);
+#elif defined(BAKED_IN_PYTHONPATH)
   setenv("PYTHONPATH", _BAKED_IN_PYTHONPATH, 1);
 #endif
 

--- a/cinderx/RuntimeTests/main.cpp
+++ b/cinderx/RuntimeTests/main.cpp
@@ -2,17 +2,6 @@
 
 #include <gtest/gtest.h>
 
-// Keep BUCK_BUILD as a synonym for the split RuntimeTests features so the
-// internal Buck target keeps its existing behavior.
-#ifdef BUCK_BUILD
-#ifndef CINDERX_RUNTIME_TESTS_USE_BUCK_RESOURCES
-#define CINDERX_RUNTIME_TESTS_USE_BUCK_RESOURCES 1
-#endif
-#ifndef CINDERX_RUNTIME_TESTS_STATIC_CINDERX
-#define CINDERX_RUNTIME_TESTS_STATIC_CINDERX 1
-#endif
-#endif
-
 #ifdef CINDERX_RUNTIME_TESTS_STATIC_CINDERX
 #include "cinderx/_cinderx-lib.h"
 #endif

--- a/cinderx/RuntimeTests/testutil.cpp
+++ b/cinderx/RuntimeTests/testutil.cpp
@@ -194,7 +194,7 @@ std::unique_ptr<HIRTestSuite> ReadHIRTestSuite(const std::string& suite_path) {
         fmt::format("Failed opening test data file: {}", strerror(errno))};
   }
   FileGuard g(file);
-  Reader reader(file, path);
+  Reader reader(file, path.string());
 
   auto suite = initTestSuite(reader);
 

--- a/setup.py
+++ b/setup.py
@@ -415,6 +415,10 @@ class BuildExt(build_ext):
             if self.cinderx_pgo_profile_path:
                 cmake_args.append(f"-DPGO_PROFILE_FILE={self.cinderx_pgo_profile_path}")
 
+        build_runtime_tests = os.environ.get("CINDERX_BUILD_RUNTIME_TESTS") == "1"
+        if build_runtime_tests:
+            cmake_args.append("-DBUILD_RUNTIME_TESTS=ON")
+
         # LTO configuration
         enable_lto = os.environ.get("CINDERX_ENABLE_LTO", None)
         if enable_lto is not None:
@@ -484,6 +488,9 @@ class BuildExt(build_ext):
         self.spawn(["cmake"] + cmake_args + ["-B", build_dir, CHECKOUT_ROOT_DIR])
         self.spawn(["cmake", "--build", build_dir] + build_args)
 
+        if build_runtime_tests:
+            self._copy_runtime_tests(build_dir)
+
         # CMake produces the extension without an ABI tag (e.g., "_cinderx.pyd"
         # or "_cinderx.so").  Rename to include the tag so the file matches what
         # setuptools/wheel packaging expects (e.g., "_cinderx.cp314-win_amd64.pyd").
@@ -495,6 +502,23 @@ class BuildExt(build_ext):
         if os.path.exists(cmake_output) and cmake_output != ext_fullpath:
             print(f"Renaming {cmake_output} -> {ext_fullpath}")
             shutil.copy(cmake_output, ext_fullpath)
+
+    def _copy_runtime_tests(self, build_dir: str) -> None:
+        output_dir = os.environ.get("CINDERX_RUNTIME_TESTS_OUTPUT_DIR")
+        if output_dir is None:
+            return
+
+        runtime_tests_name = (
+            "RuntimeTests.exe" if platform.system() == "Windows" else "RuntimeTests"
+        )
+        runtime_tests_path = os.path.join(build_dir, runtime_tests_name)
+        if not os.path.exists(runtime_tests_path):
+            raise RuntimeError(f"RuntimeTests binary not found: {runtime_tests_path}")
+
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, runtime_tests_name)
+        print(f"Copying {runtime_tests_path} -> {output_path}")
+        shutil.copy(runtime_tests_path, output_path)
 
     def _find_python(self) -> str:
         # Normally this would use "data", but that goes to a temporary build directory


### PR DESCRIPTION
T269778952

Adds an opt-in CMake target that builds the C++ GoogleTest RuntimeTests binary in OSS, plus a CI job that builds and runs it on Linux, macOS, and Windows.

Changes:
- CMakeLists.txt: add BUILD_RUNTIME_TESTS option (default OFF). When ON, fetches GoogleTest v1.15.2, requests the Python Development.Embed component, and declares a RuntimeTests executable target that links the existing CinderX libraries plus _cinderx-lib (so PyInit__cinderx is statically available). Registers the binary via add_test() with WORKING_DIRECTORY set to PROJECT_SOURCE_DIR so the existing non-Buck 'RuntimeTests/hir_tests/' + path fallback in main.cpp resolves. BAKED_IN_PYTHONPATH is set to cinderx/PythonLib so runStaticCode / runCinderCode can import the in-tree cinderx package.
- cinderx/RuntimeTests/main.cpp: split the existing #ifdef BUCK_BUILD regions into two finer-grained macros: CINDERX_TEST_USE_BUCK_RESOURCES - guards tools/cxx/Resources.h and boost::filesystem usage. Set only under Buck. CINDERX_TEST_STATIC_CINDERX - guards PyInit__cinderx + the PyImport_AppendInittab bootstrap. Set under both Buck and the new OSS CMake target. BUCK_BUILD remains a synonym that auto-defines both macros so the internal Buck build keeps working until its BUCK file is updated in a follow-up. Also wraps <sys/resource.h> + setrlimit in #ifndef _WIN32, and adds a small portable setPythonPath() shim around setenv / _putenv_s so the binary links on Windows.
- cinderx/RuntimeTests/backend_test.cpp: switch the Resources.h include to the new CINDERX_TEST_USE_BUCK_RESOURCES gate (BUCK_BUILD remains a synonym).
- .github/workflows/ci.yml: new run_native_tests job that mirrors the existing run_tests matrix (ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest) and runs: cmake -S . -B build -G Ninja -DBUILD_RUNTIME_TESTS=ON -DPY_VERSION=3.14 cmake --build build -j ctest --test-dir build --output-on-failure

Follow-ups:
- Update the internal cinderx/RuntimeTests/BUCK file to set the new CINDERX_TEST_USE_BUCK_RESOURCES / CINDERX_TEST_STATIC_CINDERX defines directly and drop the BUCK_BUILD synonym.