### PR TITLE
[cinderx] Add Python 3.15 beta OSS CI to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: '3.14t'
+          - os: ubuntu-latest
+            python-version: '3.15.0-beta.1'
+          - os: ubuntu-24.04-arm
+            python-version: '3.15.0-beta.1'
 
     steps:
     - name: Checkout CinderX
@@ -27,6 +31,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Summary:
Add Python 3.15.0 beta 1 to the GitHub Actions test matrix so OSS CI exercises the upcoming CPython release across existing platforms. Allow prerelease resolution in setup-python for the beta interpreter.

Test Plan:
Parsed .github/workflows/ci.yml with Ruby YAML parser.

Tasks: T272173181