### PR TITLE
Address all pytest warnings

### DIFF
--- a/cinderx/PythonLib/__static__/__init__.py
+++ b/cinderx/PythonLib/__static__/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import functools
 import random
-from asyncio import iscoroutinefunction
+from inspect import iscoroutinefunction
 from types import UnionType as typesUnion
 
 # pyre-ignore[21]: No _GenericAlias, _tp_cache

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/common.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/common.py
@@ -109,7 +109,7 @@ def get_child(mod: ModuleTable, name: str) -> Value | None:
     return mod.get_child(name, TEST_OPT_OUT)
 
 
-class TestCompiler(Compiler):
+class CompilerHarness(Compiler):
     def __init__(
         self,
         source_by_name: Mapping[str, str],
@@ -190,13 +190,13 @@ class TestCompiler(Compiler):
 
     def type_error(
         self, name: str, pattern: str, at: str | None = None
-    ) -> TestCompiler:
+    ) -> CompilerHarness:
         source = self.source_by_name[name]
         with self.test_case.type_error_ctx(source, pattern, at):
             self.compile_module(name)
         return self
 
-    def revealed_type(self, name: str, type: str) -> TestCompiler:
+    def revealed_type(self, name: str, type: str) -> CompilerHarness:
         source = self.source_by_name[name]
         with self.test_case.revealed_type_ctx(source, type):
             self.compile_module(name)
@@ -428,14 +428,14 @@ class StaticTestBase(CompilerTest):
     def _clean_sources(self, sources: dict[str, str]) -> dict[str, str]:
         return {name: self.clean_code(code) for name, code in sources.items()}
 
-    def compiler(self, **sources: str) -> TestCompiler:
-        return TestCompiler(self._clean_sources(sources), self)
+    def compiler(self, **sources: str) -> CompilerHarness:
+        return CompilerHarness(self._clean_sources(sources), self)
 
-    def strict_compiler(self, **sources: str) -> TestCompiler:
-        return TestCompiler(self._clean_sources(sources), self, strict_modules=True)
+    def strict_compiler(self, **sources: str) -> CompilerHarness:
+        return CompilerHarness(self._clean_sources(sources), self, strict_modules=True)
 
-    def strict_patch_compiler(self, **sources: str) -> TestCompiler:
-        return TestCompiler(
+    def strict_patch_compiler(self, **sources: str) -> CompilerHarness:
+        return CompilerHarness(
             self._clean_sources(sources),
             self,
             strict_modules=True,

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_context_decorator.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_context_decorator.py
@@ -5,8 +5,10 @@
 from __static__ import ContextDecorator
 
 import asyncio
+import gc
 import inspect
 import sys
+import warnings
 
 from .common import StaticTestBase
 
@@ -677,9 +679,18 @@ class ContextDecoratorTests(StaticTestBase):
         async def f() -> int:
             return 42
 
-        # just checking to make sure this doesn't leak
-        # in ref leak tests
-        x = f()  # noqa: F841
+        # Collecting the coroutine without awaiting it triggers a
+        # RuntimeWarning.  Capture and ignore it, the point of this test is to
+        # test for ref leaks.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="coroutine .* was never awaited",
+                category=RuntimeWarning,
+            )
+            x = f()
+            del x
+            gc.collect()
 
     def test_nonstatic_override(self) -> None:
         class C(ContextDecorator):
@@ -961,7 +972,7 @@ class ContextDecoratorTests(StaticTestBase):
         async def f() -> None:
             pass
 
-        self.assertTrue(asyncio.iscoroutinefunction(f))
+        self.assertTrue(inspect.iscoroutinefunction(f))
 
     def test_nonstatic_signature(self) -> None:
         class C(ContextDecorator):
@@ -988,8 +999,14 @@ class ContextDecoratorTests(StaticTestBase):
         async def f() -> None:
             pass
 
-        x = f()  # noqa: F841
+        # __enter__ is not called immediately.
+        x = f()
         self.assertFalse(enter_called)
+
+        # Driving `x` directly will call it.
+        with self.assertRaises(StopIteration):
+            x.send(None)
+        self.assertTrue(enter_called)
 
     def test_nonstatic_async_return_tuple_on_throw(self) -> None:
         class C(ContextDecorator):

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_dependencies.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_dependencies.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from cinderx.compiler.static.module_table import find_transitive_deps
 
-from .common import StaticTestBase, TestCompiler
+from .common import CompilerHarness, StaticTestBase
 
 
 class DependencyTrackingTests(StaticTestBase):
@@ -429,7 +429,7 @@ class DependencyTrackingTests(StaticTestBase):
 
 
 class GetDependenciesTests(StaticTestBase):
-    def assertDeps(self, compiler: TestCompiler, mod: str, deps: set[str]) -> None:
+    def assertDeps(self, compiler: CompilerHarness, mod: str, deps: set[str]) -> None:
         self.assertEqual(
             deps,
             {mod.name for mod in compiler.modules[mod].get_dependencies()},

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_imports.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_imports.py
@@ -25,7 +25,7 @@ class ResolveRelativeImportTests(unittest.TestCase):
 
     These test the name manipulation logic directly, without needing the full
     static compiler infrastructure. This lets us test __init__.py handling
-    which the TestCompiler infra can't exercise (its _get_filename never
+    which the CompilerHarness infra can't exercise (its _get_filename never
     produces __init__.py filenames).
     """
 

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_module.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_module.py
@@ -5,11 +5,11 @@
 from cinderx.compiler.static.module_table import ModuleTableException
 from cinderx.compiler.static.types import Class, ModuleInstance, TypedSyntaxError
 
-from .common import get_child, StaticTestBase, TestCompiler
+from .common import get_child, StaticTestBase, CompilerHarness
 
 
 class ModuleTests(StaticTestBase):
-    def decl_visit(self, **modules: str) -> TestCompiler:
+    def decl_visit(self, **modules: str) -> CompilerHarness:
         compiler = self.compiler(**modules)
         for name in modules.keys():
             compiler.import_module(name, optimize=0)

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_pyrefly_binder.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_pyrefly_binder.py
@@ -18,7 +18,7 @@ from cinderx.compiler.static.pyrefly_info import (
 from .common import StaticTestBase
 
 
-class TestPyrefly(Pyrefly):
+class PyreflyHarness(Pyrefly):
     def __init__(self, info: PyreflyTypeInfo):
         self.info = info
 
@@ -26,7 +26,7 @@ class TestPyrefly(Pyrefly):
         return self.info
 
 
-EMPTY_PYREFLY = TestPyrefly(EMPTY_TYPE_INFO)
+EMPTY_PYREFLY = PyreflyHarness(EMPTY_TYPE_INFO)
 
 
 class PyreBinderTests(StaticTestBase):
@@ -142,7 +142,7 @@ class PyreBinderTests(StaticTestBase):
         ast_optimizer_enabled: bool = True,
         enable_patching: bool = False,
     ) -> CodeType:
-        compiler = PyreflyCompiler(pyrefly=TestPyrefly(type_info))
+        compiler = PyreflyCompiler(pyrefly=PyreflyHarness(type_info))
         tree = ast.parse(self.clean_code(code))
         return compiler.compile(
             modname,


### PR DESCRIPTION
Summary:

* asyncio.iscoroutinefunction() is deprecated and replaced with inspect.iscoroutinefunction().

* Using class names `TestCompiler` and `TestPyrefly` makes pytest think they have `test_` methods to run.  Rename them to `FooHarness` instead.

* Fix warnings about unawaited coroutines in context decorator tests.

Test Plan:

`uv run pytest cinderx/PythonLib/test_cinderx`