### PR TITLE
Trim CI to most recent 4 micro versions, add 3.14.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         # Test against multiple patch versions as CinderX references internal
         # CPython functions and structures which can lead to ABI problems.  See
         # cinderx/UpstreamBorrow for more details.
-        python-version: ['3.14.0', '3.14.1', '3.14.2', '3.14.3', '3.14.4', '3.14.5']
+        python-version: ['3.14.3', '3.14.4', '3.14.5', '3.14.6']
         include:
           - os: ubuntu-latest
             python-version: '3.14t'


### PR DESCRIPTION
Summary:

At this point we shouldn't need to test Python 3.14.0 - 3.14.3.  Folks are generally going to have more recent micro versions installed.  Verifying the most recent 4 micro versions should be acceptable.

Test Plan:

OSS CI failing with known LIR test breakage on ARM + 3.15beta1, but Linux x86-64 on Python 3.14.6 is green.