### PR TITLE
Skip HintedCodeAllocationTest if linker script isn't used

### DIFF
--- a/cinderx/RuntimeTests/hinted_code_allocation_test.cpp
+++ b/cinderx/RuntimeTests/hinted_code_allocation_test.cpp
@@ -60,8 +60,11 @@ TEST_F(HintedCodeAllocationTest, AllocatesWithinCinderJitRegion) {
   // reserves the region; if these are null the test isn't testing anything.
   char* region_start = __cinder_jit_start;
   char* region_end = __cinder_jit_end;
-  ASSERT_NE(region_start, nullptr)
-      << "binary not linked with the .cinder_jit linker script";
+
+  if (region_start == nullptr) {
+    GTEST_SKIP() << "binary not linked with the .cinder_jit linker script";
+  }
+
   ASSERT_NE(region_end, nullptr)
       << "binary not linked with the .cinder_jit linker script";
   ASSERT_LT(region_start, region_end);


### PR DESCRIPTION
OSS build doesn't use the linker script, which leads this test to fail on Linux.