### PR TITLE
Fix Static Python definite-assignment check for augmented-assign RHS

### DIFF
--- a/cinderx/PythonLib/cinderx/compiler/static/definite_assignment_checker.py
+++ b/cinderx/PythonLib/cinderx/compiler/static/definite_assignment_checker.py
@@ -94,7 +94,7 @@ class DefiniteAssignmentVisitor(NodeVisitor):
         if isinstance(target, ast.Name):
             if target.id not in self.assigned:
                 self.unassigned.add(target)
-            self.generic_visit(node.value)
+            self.visit(node.value)
             return
 
         self.generic_visit(node)

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_definite_assignment.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_static/test_definite_assignment.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-strict
+
+import ast
+import unittest
+
+from cinderx.compiler.static.definite_assignment_checker import (
+    DefiniteAssignmentVisitor,
+)
+from cinderx.compiler.symbols import SymbolVisitor
+
+
+class DefiniteAssignmentTests(unittest.TestCase):
+    def _unassigned(self, src: str) -> list[str]:
+        tree = ast.parse(src)
+        symbols = SymbolVisitor(0)
+        symbols.visit(tree)
+        func = tree.body[0]
+        assert isinstance(func, ast.FunctionDef)
+        visitor = DefiniteAssignmentVisitor(symbols.scopes[func])
+        visitor.analyzeFunction(func)
+        return sorted(name.id for name in visitor.unassigned)
+
+    def test_augassign_rhs_name_read_before_assignment(self) -> None:
+        # `x += y` reads both the target `x` and the right-hand side `y`
+        # before either is assigned, so both must be reported as unassigned.
+        # Previously the bare-`Name` RHS (`y`) was dropped because the handler
+        # used generic_visit(node.value) (which visits the Name's children,
+        # never dispatching visit_Name) instead of visit(node.value).
+        self.assertEqual(
+            self._unassigned("def f():\n    x += y\n    y = 1\n"),
+            ["x", "y"],
+        )
+
+    def test_augassign_rhs_binop_read_before_assignment(self) -> None:
+        # A non-bare RHS (BinOp) already worked because generic_visit recurses
+        # into its child Name nodes; guard against regressing it.
+        self.assertEqual(
+            self._unassigned("def f():\n    x += y + 1\n    y = 1\n"),
+            ["x", "y"],
+        )
+
+    def test_plain_assign_rhs_name_read_before_assignment(self) -> None:
+        # Control: plain assignment already handled the bare-Name RHS correctly.
+        self.assertEqual(
+            self._unassigned("def f():\n    x = y\n    y = 1\n"),
+            ["y"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In `compiler/static`, `DefiniteAssignmentVisitor.visit_AugAssign` walked the right-hand side of an augmented assignment with `generic_visit(node.value)`. `generic_visit` visits a node's **children**, so when the RHS is a bare `Name` (e.g. `x += y`) it descends into that `Name`'s children and never dispatches `visit_Name` — dropping the read of `y`. The sibling `visit_Assign` deliberately uses `self.visit(node.value)` for exactly this reason (it even has a comment about ordering).

### Why it matters
`visitor.unassigned` is consumed in `StaticCodeGenerator.processBody`:

```python
visitor = DefiniteAssignmentVisitor(self.symbols.scopes[node])
visitor.analyzeFunction(node)
for unassigned in visitor.unassigned:
    node_type = self.get_type(unassigned)
    if isinstance(node_type, CInstance):
        node_type.emit_init(unassigned, gen)
```

For each name read before assignment whose static type is a primitive (`CInstance`, e.g. `int64`/`double`), codegen emits a forced zero-initialization so the unboxed C-level slot is never read uninitialized. Because the bug drops the bare-`Name` RHS read in `x += y`, a primitive local first read on an aug-assign RHS before being assigned is **not** zero-initialized, so its uninitialized native slot is read at runtime (undefined value rather than a clean error).

`x += y + 1` already worked by accident — `generic_visit` recurses into the `BinOp`'s child `Name` nodes — so only the bare-`Name` RHS slips through.

### Fix
Use `self.visit(node.value)`, matching `visit_Assign`. One line.

### Tests
Added `test_definite_assignment.py` exercising `DefiniteAssignmentVisitor` directly via the public symbol-table API:

| input | before | after |
|-------|--------|-------|
| `x += y` | `["x"]` | `["x", "y"]` |
| `x += y + 1` | `["x", "y"]` | `["x", "y"]` (unchanged) |
| `x = y` | `["y"]` | `["y"]` (unchanged) |