### PR TITLE
Fix strict-module is_mutable matching substrings of "mutable"

### DIFF
--- a/cinderx/PythonLib/cinderx/compiler/strict/code_gen_base.py
+++ b/cinderx/PythonLib/cinderx/compiler/strict/code_gen_base.py
@@ -29,7 +29,7 @@ from .feature_extractor import FeatureExtractor
 
 
 def is_mutable(node: AST) -> bool:
-    return isinstance(node, Name) and node.id in ("mutable")
+    return isinstance(node, Name) and node.id == "mutable"
 
 
 class FindClassDef(NodeVisitor):

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_strict/test_is_mutable.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_strict/test_is_mutable.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-unsafe
+from __future__ import annotations
+
+import ast
+import unittest
+
+from cinderx.compiler.strict.code_gen_base import is_mutable
+
+
+class IsMutableTests(unittest.TestCase):
+    def test_matches_only_mutable(self) -> None:
+        self.assertTrue(is_mutable(ast.Name(id="mutable")))
+
+    def test_rejects_substrings_of_mutable(self) -> None:
+        # Regression: `node.id in ("mutable")` was a substring test (the value
+        # is a str, not a tuple), so any bare-Name decorator whose id is a
+        # substring of "mutable" (e.g. @table, @able, @mut, @e) wrongly matched
+        # and was stripped from the class, disabling freezing.
+        for name in ("table", "able", "mut", "mutabl", "utable", "e", ""):
+            with self.subTest(name=name):
+                self.assertFalse(is_mutable(ast.Name(id=name)))
+
+    def test_rejects_unrelated_names(self) -> None:
+        self.assertFalse(is_mutable(ast.Name(id="frozen")))
+
+    def test_rejects_non_name_nodes(self) -> None:
+        self.assertFalse(is_mutable(ast.Constant(value="mutable")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`is_mutable` in `compiler/strict/code_gen_base.py`:

```python
def is_mutable(node: AST) -> bool:
    return isinstance(node, Name) and node.id in ("mutable")
```

`("mutable")` is a parenthesized string, **not a tuple** (no trailing comma), so `node.id in ("mutable")` is a **substring** test, not equality. Any bare-`Name` decorator whose id is a substring of `"mutable"` — e.g. `@table`, `@able`, `@mut`, `@mutabl`, `@e`, even `@""` — wrongly matches. The sibling helper in the same package, `strict/preprocessor.py`, has the intended form: `node.id == "mutable"`.

### Impact
`is_mutable` gates immutability/freezing of strict-module classes:

- `find_immutability_flag` strips matching decorators:
  ```python
  node.decorator_list = [d for d in node.decorator_list if not is_mutable(d)]
  return old_size == len(node.decorator_list)
  ```
  A class decorated with a substring-of-"mutable" name (notably `@table`) has that decorator **silently dropped** from `decorator_list` (so the decorator never runs) and is reported as mutable, so it is **not frozen**.
- `FindClassDef.visit_ClassDef` uses it to decide whether the module contains a freezable class, so detection is also wrong.

### Fix
Use `== "mutable"`, matching `preprocessor.py`. One line.

### Tests
Added `test_strict/test_is_mutable.py`:

| decorator | before | after |
|-----------|--------|-------|
| `@mutable` | matches ✓ | matches ✓ |
| `@table`, `@able`, `@mut`, `@e`, `@""` | **matches (bug)** | does not match ✓ |
| `@frozen` | no match ✓ | no match ✓ |