### PR TITLE
Fix off-by-one in exception-table emit_item at bit-24 boundary

### DIFF
--- a/cinderx/PythonLib/cinderx/compiler/pyassem.py
+++ b/cinderx/PythonLib/cinderx/compiler/pyassem.py
@@ -3647,7 +3647,7 @@ class ExceptionTable:
         assert value >= 0 and value < (1 << 30)
         CONTINUATION_BIT = 64
 
-        if value > (1 << 24):
+        if value >= (1 << 24):
             self.write_byte((value >> 24) | CONTINUATION_BIT | msb)
             msb = 0
         for i in (18, 12, 6):

--- a/cinderx/PythonLib/test_cinderx/test_compiler/test_exception_table.py
+++ b/cinderx/PythonLib/test_cinderx/test_compiler/test_exception_table.py
@@ -38,3 +38,35 @@ class EncodingTests(TestCase):
         ]
         actual = ParsedExceptionTable.from_bytes(table).entries
         self.assertEqual(expected, actual)
+
+    @staticmethod
+    def _decode_item(buf: bytes) -> int:
+        # Decode a single varint emitted by emit_item(value, msb=0): 6 data bits
+        # per byte, continuation bit (64) set on every byte but the last.
+        it = iter(buf)
+        b = next(it)
+        value = b & 0x3F
+        while b & 64:
+            b = next(it)
+            value = (value << 6) | (b & 0x3F)
+        return value
+
+    def test_emit_item_roundtrip_across_group_boundaries(self) -> None:
+        # emit_item packs a value 6 bits at a time. Each group threshold uses
+        # `value >= (1 << i)`; the top group (bit 24) must use the same `>=`.
+        # A `>` there drops bit 24 at exactly value == 1 << 24, corrupting the
+        # entry (it decodes back to 0).
+        values = []
+        for i in (6, 12, 18, 24):
+            values += [(1 << i) - 1, 1 << i, (1 << i) + 1]
+        values += [0, 1, (1 << 30) - 1]
+        for value in values:
+            with self.subTest(value=value):
+                e = ExceptionTable()
+                e.emit_item(value, 0)
+                self.assertEqual(self._decode_item(e.getTable()), value)
+
+    def test_emit_item_bit24_boundary(self) -> None:
+        e = ExceptionTable()
+        e.emit_item(1 << 24, 0)
+        self.assertEqual(self._decode_item(e.getTable()), 1 << 24)


### PR DESCRIPTION
`ExceptionTable.emit_item` in `compiler/pyassem.py` packs a value 6 bits at a time. The three lower group thresholds use `>=`, but the top group used `>`:

```python
if value > (1 << 24):                 # <- bug: should be >=
    self.write_byte((value >> 24) | CONTINUATION_BIT | msb)
    msb = 0
for i in (18, 12, 6):
    if value >= (1 << i):             # the other thresholds use >=
        ...
```

At exactly `value == 1 << 24` (16777216) the leading 6-bit group is skipped, so the value is emitted as `40 40 40 00` and decodes back to **0** — a corrupt exception-table entry. Values one below/above encode fine, so it is a precise boundary bug.

This mirrors CPythons `assemble_emit_exception_table_item` in `Python/assemble.c`, which uses `value >= 1 << 24`. The inconsistency within the same function (one `>`, three `>=`) is the tell.

### Impact
`emit_item` is fed block `start`/`size`/`target` byte-offsets and `depth_lasti` via `emit_entry`, so any of those equal to `16777216` yields a table entry that points at offset 0.

### Fix
Use `>=`, matching the other thresholds and CPython. One character.

### Tests
Added round-trip tests to `test_exception_table.py` over all four group boundaries `(1<<i)-1, 1<<i, (1<<i)+1` for `i in {6,12,18,24}` plus `0/1/(1<<30)-1`. Verified the suite fails only at `16777216` before the fix and passes after:

```
BUG(>):  failing values = [16777216]
FIX(>=): failing values = []
```