### PR TITLE
Fall back to __getattr__ when a descriptor raises in LoadMethodCache

### DIFF
--- a/cinderx/Jit/inline_cache.cpp
+++ b/cinderx/Jit/inline_cache.cpp
@@ -1622,6 +1622,15 @@ LoadMethodResult __attribute__((noinline)) LoadMethodCache::lookupSlowPath(
             cache_stats_, tp, name, CacheMissReason::kPyDescrIsData);
         PyObject* result = f(descr, obj, (PyObject*)obj->ob_type);
         Py_DECREF(descr);
+        if (result == nullptr) {
+          // Replicate slot_tp_getattr_hook semantics: an AttributeError
+          // raised by the descriptor's __get__ (e.g. an unset slot) falls
+          // back to __getattr__ rather than propagating.
+          result = tryGetAttrFallback(tp, nullptr, obj, name);
+          if (result == nullptr) {
+            return {nullptr, nullptr};
+          }
+        }
         return {Py_None, result};
       }
     }
@@ -1690,6 +1699,13 @@ LoadMethodResult __attribute__((noinline)) LoadMethodCache::lookupSlowPath(
         cache_stats_, tp, name, CacheMissReason::kUncategorized);
     PyObject* result = f(descr, obj, (PyObject*)Py_TYPE(obj));
     Py_DECREF(descr);
+    if (result == nullptr) {
+      // As above: route an AttributeError from __get__ to __getattr__.
+      result = tryGetAttrFallback(tp, nullptr, obj, name);
+      if (result == nullptr) {
+        return {nullptr, nullptr};
+      }
+    }
     return {Py_None, result};
   }
 

--- a/cinderx/PythonLib/test_cinderx/test_load_method_getattr.py
+++ b/cinderx/PythonLib/test_cinderx/test_load_method_getattr.py
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-strict
+
+"""Regression test for gh-115: an AttributeError from a descriptor's
+__get__ must fall back to __getattr__ in the JIT's method-call load
+path. Runs in a subprocess because it depends on JIT warm-up state."""
+
+import subprocess
+import sys
+import unittest
+
+import cinderx
+
+cinderx.init()
+
+from cinderx.test_support import ENCODING, subprocess_env
+
+
+def run_snippet(source: str) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [sys.executable, "-c", source],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        encoding=ENCODING,
+        env=subprocess_env(),
+    )
+
+
+class LoadMethodGetattrTests(unittest.TestCase):
+    def test_unset_slot_falls_back_to_getattr(self) -> None:
+        # An AttributeError from a descriptor's __get__ (here an unset slot)
+        # must fall back to __getattr__ in the JIT's method-call load path.
+        proc = run_snippet(
+            """if 1:
+            import cinderx.jit
+            cinderx.jit.auto()
+
+            class Base:
+                __slots__ = ("__dict__",)
+
+                def __getattr__(self, name):
+                    if name == "evt":
+                        def ls(*args):
+                            return "called"
+                        setattr(self, "evt", ls)
+                        return ls
+                    raise AttributeError(name)
+
+            D = type("D", (Base,), {"__slots__": ("evt",)})
+
+            def call_evt(d):
+                return d.evt()
+
+            assert cinderx.jit.force_compile(call_evt)
+
+            warm = D()
+            _ = warm.evt
+            assert call_evt(warm) == "called"
+
+            # Fresh instance: the slot is unset.
+            assert call_evt(D()) == "called"
+            """
+        )
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
part of https://github.com/facebookincubator/cinderx/issues/115