### PR TITLE
Stop crashing when parsing bad code size limits

### DIFF
--- a/cinderx/Jit/pyjit.cpp
+++ b/cinderx/Jit/pyjit.cpp
@@ -344,7 +344,7 @@ size_t parse_sized_argument(const std::string& val) {
   // " 1024 k" should parse OK - so remove the space.
   std::remove_copy_if(
       val.begin(), val.end(), std::back_inserter(parsed), ::isspace);
-  JIT_CHECK(!parsed.empty(), "Input string is empty");
+  JIT_THROW_IF(parsed.empty(), "Input string is empty");
   static_assert(
       sizeof(decltype(std::stoull(parsed))) == sizeof(size_t),
       "stoull parses to size_t size");
@@ -371,12 +371,12 @@ size_t parse_sized_argument(const std::string& val) {
   size_t ret_value{0};
   auto p_last = parsed.data() + parsed.size();
   auto int_ok = std::from_chars(parsed.data(), p_last, ret_value);
-  JIT_CHECK(
-      int_ok.ec == std::errc() && int_ok.ptr == p_last,
+  JIT_THROW_IF(
+      int_ok.ec != std::errc() || int_ok.ptr != p_last,
       "Invalid unsigned integer in input string: '{}'",
       val);
-  JIT_CHECK(
-      ret_value <= (std::numeric_limits<size_t>::max() / scale),
+  JIT_THROW_IF(
+      ret_value > (std::numeric_limits<size_t>::max() / scale),
       "Unsigned Integer overflow in input string: '{}'",
       val);
   return ret_value * scale;

--- a/cinderx/PythonLib/test_cinderx/test_jit_max_size.py
+++ b/cinderx/PythonLib/test_cinderx/test_jit_max_size.py
@@ -38,7 +38,6 @@ _TINY_HIR_INSTRS_LIMIT = "jit-max-hir-instrs=1"
 _TINY_HIR_BLOCKS_LIMIT = "jit-max-hir-blocks=1"
 _TINY_LIR_INSTRS_LIMIT = "jit-max-lir-instrs=1"
 _TINY_LIR_BLOCKS_LIMIT = "jit-max-lir-blocks=1"
-_WINDOWS_STATUS_STACK_BUFFER_OVERRUN = 0xC0000409
 
 # A trivial straight-line function: >1 instruction, 1 basic block (HIR or LIR).
 _STRAIGHT_LINE = """
@@ -306,12 +305,7 @@ class SizeLimitTest(unittest.TestCase):
                     encoding=ENCODING,
                     env=subprocess_env(),
                 )
-                expected_returncode = (
-                    _WINDOWS_STATUS_STACK_BUFFER_OVERRUN
-                    if sys.platform == "win32"
-                    else -signal.SIGABRT
-                )
-                self.assertEqual(proc.returncode, expected_returncode, proc)
+                self.assertNotEqual(proc.returncode, 0, proc)
                 return proc.stderr
 
             self.assertIn(


### PR DESCRIPTION
Summary:

The use of JIT_CHECK here means that importing the module will crash the entire process if a bad code size limit is passed in.  Use JIT_THROW_IF() instead, this will be caught by cinderx_exec() and convert to a proper RuntimeError.

Test Plan:

`uv run pytest cinderx/PythonLib`

no longer raises alerts on Fedora about `python3.14` crashes.