### PR TITLE
Fix AssertionError when a dynamic value is returned as a primitive int

### DIFF
--- a/cinderx/PythonLib/cinderx/compiler/static/types.py
+++ b/cinderx/PythonLib/cinderx/compiler/static/types.py
@@ -9632,13 +9632,18 @@ class CIntInstance(CInstance["CIntType"]):
     def emit_unbox(self, node: expr, code_gen: StaticCodeGenBase) -> None:
         code_gen.visit(node)
         ty = code_gen.get_type(node)
+        self.emit_unbox_from_stack(ty.klass, code_gen)
+
+    def emit_unbox_from_stack(self, src: Class, code_gen: StaticCodeGenBase) -> None:
+        """Unbox a value of (possibly dynamic) type `src` that is already on
+        the stack, converting it to this primitive int type."""
         target_ty = (
             self.klass.type_env.bool
             if self.klass is self.klass.type_env.cbool
             else self.klass.type_env.int
         )
-        if target_ty.can_assign_from(ty.klass):
-            code_gen.emit("REFINE_TYPE", ty.klass.type_descr)
+        if target_ty.can_assign_from(src):
+            code_gen.emit("REFINE_TYPE", src.type_descr)
         else:
             code_gen.emit("CAST", target_ty.type_descr)
         code_gen.emit("PRIMITIVE_UNBOX", self.as_oparg())
@@ -9783,8 +9788,16 @@ class CIntType(CType):
         return False
 
     def emit_type_check(self, src: Class, code_gen: StaticCodeGenBase) -> None:
-        assert self.can_assign_from(src)
-        self.instance.emit_convert(src.instance, code_gen)
+        if isinstance(src, CIntType):
+            assert self.can_assign_from(src)
+            self.instance.emit_convert(src.instance, code_gen)
+            return
+        # src is not statically known to be a primitive int (e.g. it's
+        # dynamic, or a union involving dynamic, which the binder allows
+        # through here) - unbox it at runtime instead of asserting, mirroring
+        # how a boxed/dynamic value is coerced everywhere else it's narrowed
+        # to a primitive int (see emit_call below and emit_unbox).
+        self.instance.emit_unbox_from_stack(src, code_gen)
 
     def emit_call(self, node: ast.Call, code_gen: StaticCodeGenBase) -> None:
         if len(node.args) != 1:


### PR DESCRIPTION
## Summary
`CIntType.emit_type_check` only handled sources that were already a `CIntType`, so returning a dynamically-typed value (e.g. from an untyped param, or after a branch that joins with a dynamic type) into a primitive `int64`-declared return crashed the compiler with a bare `AssertionError` instead of compiling. This reproduces even without branching:

```python
def f(a) -> int64:
    return a
```

`TypeBinder.visitReturn` already permits a `dynamic` value to flow into a primitive return type (it only errors when the returned type isn't exactly `dynamic`), expecting codegen to unbox at runtime - but `CIntType.emit_type_check` never implemented that fallback, unlike the generic `Class.emit_type_check`, which emits a `CAST` for dynamic
sources.

## Fix
Extracted the existing box-to-primitive unboxing sequence (already used by `emit_call`/`emit_unbox`: `CAST`/`REFINE_TYPE` + `PRIMITIVE_UNBOX`) into `emit_unbox_from_stack`, and have `CIntType.emit_type_check` fall back to it when `src` isn't a known `CIntType`.

## Tests
- Reproduced the crash and verified the fix with a standalone script driving `Compiler(StaticCodeGenerator).compile(...)` directly.
- Confirmed correct runtime behavior: valid ints unbox and return properly; a bad type now raises a clean `TypeError` instead of crashing the compiler.
- Ran the full `test_static` suite (3919 tests): all pass, no regressions (63 pre-existing skips).

Fixes #150
