### PR TITLE
Name extension using Python SOABI tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,12 @@ target_link_libraries(
   borrowed cached-properties common immortalize interpreter jit parallel-gc static-python
   asmjit::asmjit fmt::fmt)
 
-add_library(${PROJECT_NAME} SHARED ${PROJECT_SOURCE_DIR}/_cinderx.cpp)
+Python_add_library(
+  ${PROJECT_NAME}
+  MODULE
+  WITH_SOABI
+  ${PROJECT_SOURCE_DIR}/_cinderx.cpp
+)
 
 target_link_libraries(
   ${PROJECT_NAME}
@@ -479,12 +484,14 @@ if (${MACOS})
   target_link_options(${PROJECT_NAME} PRIVATE -undefined dynamic_lookup)
 endif()
 
-set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
-set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX "")
-if (WINDOWS)
-    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "_cinderx.pyd")
-else()
-    set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "_cinderx.so")
+if (NOT WINDOWS)
+  add_custom_command(
+    TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+      $<TARGET_FILE_NAME:${PROJECT_NAME}>
+      $<TARGET_FILE_DIR:${PROJECT_NAME}>/_cinderx.so
+    COMMENT "Creating _cinderx.so symlink pointing to $<TARGET_FILE_NAME:${PROJECT_NAME}>"
+  )
 endif()
 
 ##############################################################################

--- a/setup.py
+++ b/setup.py
@@ -449,6 +449,7 @@ class BuildExt(build_ext):
         py_version = compute_py_version()
         options["PY_VERSION"] = py_version
         options["Python_ROOT_DIR"] = self._find_python()
+        options["Python_EXECUTABLE"] = sys.executable
 
         meta_python = "+meta" in sys.version
         linux = sys.platform == "linux"
@@ -498,17 +499,8 @@ class BuildExt(build_ext):
         if build_runtime_tests:
             self._copy_runtime_tests(build_dir)
 
-        # CMake produces the extension without an ABI tag (e.g., "_cinderx.pyd"
-        # or "_cinderx.so").  Rename to include the tag so the file matches what
-        # setuptools/wheel packaging expects (e.g., "_cinderx.cp314-win_amd64.pyd").
-        if platform.system() == "Windows":
-            cmake_output_name = f"{extension.name}.pyd"
-        else:
-            cmake_output_name = f"{extension.name}.so"
-        cmake_output = os.path.join(self.build_temp, cmake_output_name)
-        if os.path.exists(cmake_output) and cmake_output != ext_fullpath:
-            print(f"Renaming {cmake_output} -> {ext_fullpath}")
-            shutil.copy(cmake_output, ext_fullpath)
+        if not os.path.exists(ext_fullpath):
+            raise RuntimeError(f"CMake extension output not found: {ext_fullpath}")
 
     def _copy_runtime_tests(self, build_dir: str) -> None:
         output_dir = os.environ.get("CINDERX_RUNTIME_TESTS_OUTPUT_DIR")


### PR DESCRIPTION
Use CMake's `Python_add_library(... MODULE WITH_SOABI)` to name the compiled extension with its Python ABI tag, and create an unversioned `_cinderx.so` symlink on non-Windows for backward compatibility.

This allows GIL and free-threaded builds to coexist side-by-side in `cinderx/PythonLib/`.